### PR TITLE
PowerRanks v1.10.6 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 									<exclude>META-INF/license/**</exclude>
 									<exclude>META-INF/*</exclude>
 									<exclude>META-INF/maven/**</exclude>
+									<exclude>META-INF/versions/*/module-info.class</exclude>
 									<exclude>LICENSE</exclude>
 									<exclude>NOTICE</exclude>
 									<exclude>/*.txt</exclude>
@@ -240,7 +241,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18.1-R0.1-SNAPSHOT</version>
+			<version>1.19.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<src.dir>src/main/java</src.dir>
 		<rsc.dir>src/main/resources</rsc.dir>
 		<shade.basepattern>nl.svenar.lib</shade.basepattern>
-		<testserver.location>../../minecraft/java/bukkit_pr_v1/plugins</testserver.location>
+		<testserver.location>../../minecraft/java/bungeecord/bukkit_plugins</testserver.location>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>4.9.2</version>
+			<version>4.9.3</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>
@@ -199,7 +199,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2</version>
+			<version>2.13.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.svenar</groupId>
 	<artifactId>powerranks</artifactId>
-	<version>1.10.6 BETA 2</version>
+	<version>1.10.6</version>
 	<name>PowerRanks</name>
 	<description>An amazing permission plugin!</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.26</version>
+			<version>[2.0,)</version>
 			<type>jar</type>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.svenar</groupId>
 	<artifactId>powerranks</artifactId>
-	<version>1.10.5R2</version>
+	<version>1.10.6 BETA</version>
 	<name>PowerRanks</name>
 	<description>An amazing permission plugin!</description>
 
@@ -194,17 +194,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.9.6</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.8</version>
+			<version>2.13.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>2.9.0</version>
+			<version>2.13.2</version>
 			<type>jar</type>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.svenar</groupId>
 	<artifactId>powerranks</artifactId>
-	<version>1.10.6 BETA</version>
+	<version>1.10.6 BETA 2</version>
 	<name>PowerRanks</name>
 	<description>An amazing permission plugin!</description>
 
@@ -12,7 +12,7 @@
 		<src.dir>src/main/java</src.dir>
 		<rsc.dir>src/main/resources</rsc.dir>
 		<shade.basepattern>nl.svenar.lib</shade.basepattern>
-		<testserver.location>../../minecraft/java/bungeecord/bukkit_plugins</testserver.location>
+		<testserver.location>../../minecraft/java/latest_server/plugins/</testserver.location>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.svenar</groupId>
 	<artifactId>powerranks</artifactId>
-	<version>1.10.5</version>
+	<version>1.10.5R2</version>
 	<name>PowerRanks</name>
 	<description>An amazing permission plugin!</description>
 

--- a/src/main/java/nl/svenar/PowerRanks/Cache/CacheManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Cache/CacheManager.java
@@ -24,6 +24,7 @@ import nl.svenar.common.storage.provided.PSMStorageManager;
 import nl.svenar.common.storage.provided.SQLiteStorageManager;
 import nl.svenar.common.storage.provided.YAMLStorageManager;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class CacheManager {
@@ -125,7 +126,8 @@ public class CacheManager {
         prPlayer.setUUID(player.getUniqueId());
         prPlayer.setName(player.getName());
         for (PRRank rank : CacheManager.getDefaultRanks()) {
-            prPlayer.addRank(rank.getName());
+            PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+            prPlayer.addRank(playerRank);
         }
         CacheManager.addPlayer(prPlayer);
         return prPlayer;

--- a/src/main/java/nl/svenar/PowerRanks/Cache/CacheManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Cache/CacheManager.java
@@ -3,7 +3,9 @@ package nl.svenar.PowerRanks.Cache;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.Map.Entry;
 
 import org.bukkit.Bukkit;
@@ -160,7 +162,7 @@ public class CacheManager {
                         pcm.getString("storage.mysql.database", "powerranks"),
                         pcm.getString("storage.mysql.username", "username"),
                         pcm.getString("storage.mysql.password", "password"),
-                        pcm.getBool("storage.mysql.ssl", false), "ranks", "players");
+                        pcm.getBool("storage.mysql.ssl", false), "ranks", "players", "messages");
                 storageManager = new MySQLStorageManager(configuration, pcm.getBool("storage.mysql.verbose", false));
             } else { // Default to yaml
 
@@ -226,5 +228,37 @@ public class CacheManager {
 
     public static void configConverterSetDefaultRank(String rankname) {
         tmpConvertDefaultRank = rankname;
+    }
+
+    // Bungeecord methods
+
+    public static void postDBMessage(UUID uuid, String key, String message) {
+        if (!(getStorageManager() instanceof MySQLStorageManager)) {
+            return;
+        }
+        MySQLStorageManager localStorageManager = (MySQLStorageManager) getStorageManager();
+        localStorageManager.SQLInsert(localStorageManager.getConfig().getDatabase(), localStorageManager.getConfig().getTableMessages(), uuid.toString() + "." + key, message);
+    }
+
+    public static Map<String, String> getDBBroadcastMessages() {
+        return getDBMessages(UUID.fromString("00000000-0000-0000-0000-000000000000"));
+    }
+
+    public static Map<String, String> getDBMessages(UUID uuid) {
+        if (!(getStorageManager() instanceof MySQLStorageManager)) {
+            return null;
+        }
+        MySQLStorageManager localStorageManager = (MySQLStorageManager) getStorageManager();
+
+        Map<String, String> messages = localStorageManager.selectSimiliarInTable(localStorageManager.getConfig().getDatabase(), localStorageManager.getConfig().getTableMessages(), uuid.toString());
+        return messages;
+    }
+
+    public static void removeDBMessage(UUID uuid, String key) {
+        if (!(getStorageManager() instanceof MySQLStorageManager)) {
+            return;
+        }
+        MySQLStorageManager localStorageManager = (MySQLStorageManager) getStorageManager();
+        localStorageManager.deleteKeyInTable(localStorageManager.getConfig().getDatabase(), localStorageManager.getConfig().getTableMessages(),uuid.toString() + "." + key);
     }
 }

--- a/src/main/java/nl/svenar/PowerRanks/Cache/LanguageManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Cache/LanguageManager.java
@@ -114,14 +114,21 @@ public class LanguageManager {
     }
 
     /**
-     * Save the language data to the files system.
+     * Save the language data to the files system
      */
     public void save() {
         this.languageManager.save();
     }
+    /**
+     * Reload the language data
+     */
+    public void reload() {
+        this.languageManager.reload();
+    }
 
     /**
      * Get the config file instance
+     * 
      * @return PowerConfigManager for lang.yml
      */
     public PowerConfigManager getInstance() {

--- a/src/main/java/nl/svenar/PowerRanks/Commands/PowerCommandHandler.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/PowerCommandHandler.java
@@ -33,6 +33,7 @@ import nl.svenar.PowerRanks.Commands.core.cmd_help;
 import nl.svenar.PowerRanks.Commands.core.cmd_pluginhook;
 import nl.svenar.PowerRanks.Commands.core.cmd_reload;
 import nl.svenar.PowerRanks.Commands.core.cmd_stats;
+import nl.svenar.PowerRanks.Commands.core.cmd_tablist;
 import nl.svenar.PowerRanks.Commands.core.cmd_verbose;
 import nl.svenar.PowerRanks.Commands.player.cmd_addownrank;
 import nl.svenar.PowerRanks.Commands.player.cmd_addplayerperm;
@@ -88,6 +89,7 @@ public class PowerCommandHandler implements CommandExecutor {
 		new cmd_verbose(plugin, "verbose", COMMAND_EXECUTOR.ALL);
 		new cmd_pluginhook(plugin, "pluginhook", COMMAND_EXECUTOR.ALL);
 		new cmd_config(plugin, "config", COMMAND_EXECUTOR.ALL);
+		new cmd_tablist(plugin, "tablist", COMMAND_EXECUTOR.ALL);
 		new cmd_stats(plugin, "stats", COMMAND_EXECUTOR.ALL);
 		new cmd_factoryreset(plugin, "factoryreset", COMMAND_EXECUTOR.ALL);
 		new cmd_addoninfo(plugin, "addoninfo", COMMAND_EXECUTOR.ALL);

--- a/src/main/java/nl/svenar/PowerRanks/Commands/buyable/cmd_buyrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/buyable/cmd_buyrank.java
@@ -16,6 +16,7 @@ import nl.svenar.PowerRanks.Data.Messages;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.External.VaultHook;
 import nl.svenar.PowerRanks.Util.Util;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_buyrank extends PowerCommand {
@@ -53,7 +54,8 @@ public class cmd_buyrank extends PowerCommand {
 						PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(rankname));
 						if (rank != null) {
 							if (rank != null) {
-								CacheManager.getPlayer(player.getUniqueId().toString()).setRank(rank.getName());
+								PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+								CacheManager.getPlayer(player.getUniqueId().toString()).setRank(playerRank);
 
 								sender.sendMessage(Util.powerFormatter(
 										PowerRanks.getLanguageManager().getFormattedMessage(

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
@@ -102,41 +102,41 @@ public class cmd_config extends PowerCommand {
 
 					PowerRanks.getConfigManager().setBool("tablist_modification.enabled", enable);
                 
-                } else if (args[1].equalsIgnoreCase("tablist_sorting")) {
-                    sender.sendMessage(Util.powerFormatter(
-                        PowerRanks.getLanguageManager().getFormattedMessage(
-                                "commands." + commandName.toLowerCase() + ".state-changed"),
-                        ImmutableMap.<String, String>builder()
-                                .put("player", sender.getName())
-                                .put("config_target", "Tablist sorting")
-                                .put("old_state",
-                                        String.valueOf(PowerRanks.getConfigManager()
-                                                .getBool("tablist_modification.sorting.enabled", true)))
-                                .put("new_state", String.valueOf(enable))
-                                .build(),
-                        '[', ']'));
+                // } else if (args[1].equalsIgnoreCase("tablist_sorting")) {
+                //     sender.sendMessage(Util.powerFormatter(
+                //         PowerRanks.getLanguageManager().getFormattedMessage(
+                //                 "commands." + commandName.toLowerCase() + ".state-changed"),
+                //         ImmutableMap.<String, String>builder()
+                //                 .put("player", sender.getName())
+                //                 .put("config_target", "Tablist sorting")
+                //                 .put("old_state",
+                //                         String.valueOf(PowerRanks.getConfigManager()
+                //                                 .getBool("tablist_modification.sorting.enabled", true)))
+                //                 .put("new_state", String.valueOf(enable))
+                //                 .build(),
+                //         '[', ']'));
 
-                PowerRanks.getConfigManager().setBool("tablist_modification.sorting.enabled", enable);
-                PowerRanks.getInstance().getTablistManager().stop();
-                PowerRanks.getInstance().getTablistManager().start();
+                // PowerRanks.getConfigManager().setBool("tablist_modification.sorting.enabled", enable);
+                // PowerRanks.getInstance().getTablistManager().stop();
+                // PowerRanks.getInstance().getTablistManager().start();
 
-                } else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
-                    sender.sendMessage(Util.powerFormatter(
-                        PowerRanks.getLanguageManager().getFormattedMessage(
-                                "commands." + commandName.toLowerCase() + ".state-changed"),
-                        ImmutableMap.<String, String>builder()
-                                .put("player", sender.getName())
-                                .put("config_target", "Reverse tablist sorting")
-                                .put("old_state",
-                                        String.valueOf(PowerRanks.getConfigManager()
-                                                .getBool("tablist_modification.sorting.reverse", true)))
-                                .put("new_state", String.valueOf(enable))
-                                .build(),
-                        '[', ']'));
+                // } else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
+                //     sender.sendMessage(Util.powerFormatter(
+                //         PowerRanks.getLanguageManager().getFormattedMessage(
+                //                 "commands." + commandName.toLowerCase() + ".state-changed"),
+                //         ImmutableMap.<String, String>builder()
+                //                 .put("player", sender.getName())
+                //                 .put("config_target", "Reverse tablist sorting")
+                //                 .put("old_state",
+                //                         String.valueOf(PowerRanks.getConfigManager()
+                //                                 .getBool("tablist_modification.sorting.reverse", true)))
+                //                 .put("new_state", String.valueOf(enable))
+                //                 .build(),
+                //         '[', ']'));
 
-                PowerRanks.getConfigManager().setBool("tablist_modification.sorting.reverse", enable);
-                PowerRanks.getInstance().getTablistManager().stop();
-                PowerRanks.getInstance().getTablistManager().start();
+                // PowerRanks.getConfigManager().setBool("tablist_modification.sorting.reverse", enable);
+                // PowerRanks.getInstance().getTablistManager().stop();
+                // PowerRanks.getInstance().getTablistManager().start();
 
 				} else if (args[1].equalsIgnoreCase("casesensitive_permissions")) {
 					sender.sendMessage(Util.powerFormatter(
@@ -287,8 +287,8 @@ public class cmd_config extends PowerCommand {
 			if (args[0].equalsIgnoreCase("enable") || args[0].equalsIgnoreCase("disable")) {
 				tabcomplete.add("chat_formatting");
 				tabcomplete.add("tablist_formatting");
-				tabcomplete.add("tablist_sorting");
-				tabcomplete.add("reverse_tablist_sorting");
+				// tabcomplete.add("tablist_sorting");
+				// tabcomplete.add("reverse_tablist_sorting");
 				tabcomplete.add("casesensitive_permissions");
 				tabcomplete.add("op");
 			}

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
@@ -101,42 +101,6 @@ public class cmd_config extends PowerCommand {
 							'[', ']'));
 
 					PowerRanks.getConfigManager().setBool("tablist_modification.enabled", enable);
-                
-                // } else if (args[1].equalsIgnoreCase("tablist_sorting")) {
-                //     sender.sendMessage(Util.powerFormatter(
-                //         PowerRanks.getLanguageManager().getFormattedMessage(
-                //                 "commands." + commandName.toLowerCase() + ".state-changed"),
-                //         ImmutableMap.<String, String>builder()
-                //                 .put("player", sender.getName())
-                //                 .put("config_target", "Tablist sorting")
-                //                 .put("old_state",
-                //                         String.valueOf(PowerRanks.getConfigManager()
-                //                                 .getBool("tablist_modification.sorting.enabled", true)))
-                //                 .put("new_state", String.valueOf(enable))
-                //                 .build(),
-                //         '[', ']'));
-
-                // PowerRanks.getConfigManager().setBool("tablist_modification.sorting.enabled", enable);
-                // PowerRanks.getInstance().getTablistManager().stop();
-                // PowerRanks.getInstance().getTablistManager().start();
-
-                // } else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
-                //     sender.sendMessage(Util.powerFormatter(
-                //         PowerRanks.getLanguageManager().getFormattedMessage(
-                //                 "commands." + commandName.toLowerCase() + ".state-changed"),
-                //         ImmutableMap.<String, String>builder()
-                //                 .put("player", sender.getName())
-                //                 .put("config_target", "Reverse tablist sorting")
-                //                 .put("old_state",
-                //                         String.valueOf(PowerRanks.getConfigManager()
-                //                                 .getBool("tablist_modification.sorting.reverse", true)))
-                //                 .put("new_state", String.valueOf(enable))
-                //                 .build(),
-                //         '[', ']'));
-
-                // PowerRanks.getConfigManager().setBool("tablist_modification.sorting.reverse", enable);
-                // PowerRanks.getInstance().getTablistManager().stop();
-                // PowerRanks.getInstance().getTablistManager().start();
 
 				} else if (args[1].equalsIgnoreCase("casesensitive_permissions")) {
 					sender.sendMessage(Util.powerFormatter(
@@ -169,22 +133,6 @@ public class cmd_config extends PowerCommand {
 							'[', ']'));
 
 					PowerRanks.getConfigManager().setBool("general.disable-op", !enable);
-
-					// } else if (args[1].equalsIgnoreCase("language")) {
-					// sender.sendMessage(Util.powerFormatter(
-					// PowerRanks.getLanguageManager().getFormattedMessage(
-					// "commands." + commandName.toLowerCase() + ".state-changed"),
-					// ImmutableMap.<String, String>builder()
-					// .put("player", sender.getName())
-					// .put("config_target", "PowerRanks language (lang.yml)")
-					// .put("old_state",
-					// String.valueOf(!PowerRanks.getConfigManager()
-					// .getBool("general.language", true)))
-					// .put("new_state", String.valueOf(enable))
-					// .build(),
-					// '[', ']'));
-
-					// PowerRanks.getConfigManager().setBool("general.language", !enable);
 
 				} else {
 					sender.sendMessage(
@@ -287,8 +235,6 @@ public class cmd_config extends PowerCommand {
 			if (args[0].equalsIgnoreCase("enable") || args[0].equalsIgnoreCase("disable")) {
 				tabcomplete.add("chat_formatting");
 				tabcomplete.add("tablist_formatting");
-				// tabcomplete.add("tablist_sorting");
-				// tabcomplete.add("reverse_tablist_sorting");
 				tabcomplete.add("casesensitive_permissions");
 				tabcomplete.add("op");
 			}

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_config.java
@@ -134,6 +134,22 @@ public class cmd_config extends PowerCommand {
 
 					PowerRanks.getConfigManager().setBool("general.disable-op", !enable);
 
+				} else if (args[1].equalsIgnoreCase("bungeecord")) {
+					sender.sendMessage(Util.powerFormatter(
+							PowerRanks.getLanguageManager().getFormattedMessage(
+									"commands." + commandName.toLowerCase() + ".state-changed"),
+							ImmutableMap.<String, String>builder()
+									.put("player", sender.getName())
+									.put("config_target", "Bungeecord integration")
+									.put("old_state",
+											String.valueOf(PowerRanks.getConfigManager()
+													.getBool("bungeecord.enabled", false)))
+									.put("new_state", String.valueOf(enable))
+									.build(),
+							'[', ']'));
+
+					PowerRanks.getConfigManager().setBool("bungeecord.enabled", enable);
+
 				} else {
 					sender.sendMessage(
 							PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
@@ -188,6 +204,22 @@ public class cmd_config extends PowerCommand {
 
 				PowerRanks.getConfigManager().setString("general.language", args[2]);
 
+			} else if (args[1].equalsIgnoreCase("bungeecord_server_name")) {
+				sender.sendMessage(Util.powerFormatter(
+						PowerRanks.getLanguageManager().getFormattedMessage(
+								"commands." + commandName.toLowerCase() + ".state-changed"),
+						ImmutableMap.<String, String>builder()
+								.put("player", sender.getName())
+								.put("config_target", "PowerRanks Bungeecord server name")
+								.put("old_state",
+										String.valueOf(PowerRanks.getConfigManager()
+												.getString("bungeecors.server-name", "Global")))
+								.put("new_state", args[2])
+								.build(),
+						'[', ']'));
+
+				PowerRanks.getConfigManager().setString("bungeecors.server-name", args[2]);
+
 			} else if (args[1].equalsIgnoreCase("autosave_files_interval")) {
 				try {
 					int time = Integer.parseInt(args[2]);
@@ -227,8 +259,8 @@ public class cmd_config extends PowerCommand {
 		if (args.length == 1) {
 			tabcomplete.add("removeworldtag");
 			tabcomplete.add("enable");
-			tabcomplete.add("set");
 			tabcomplete.add("disable");
+			tabcomplete.add("set");
 		}
 
 		if (args.length == 2) {
@@ -237,6 +269,7 @@ public class cmd_config extends PowerCommand {
 				tabcomplete.add("tablist_formatting");
 				tabcomplete.add("casesensitive_permissions");
 				tabcomplete.add("op");
+				tabcomplete.add("bungeecord");
 			}
 		}
 
@@ -245,6 +278,7 @@ public class cmd_config extends PowerCommand {
 				tabcomplete.add("language");
 				tabcomplete.add("autosave_files_interval");
 				tabcomplete.add("playtime_update_interval");
+				tabcomplete.add("bungeecord_server_name");
 			}
 		}
 

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_reload.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_reload.java
@@ -36,7 +36,11 @@ public class cmd_reload extends PowerCommand {
 						PowerRanks.getLanguageManager().getFormattedMessage(
 								"commands." + commandName.toLowerCase() + ".config-start"));
 
-				PowerRanks.getConfigManager().reload();
+                PowerRanks.getConfigManager().reload();
+                PowerRanks.getLanguageManager().reload();
+                PowerRanks.getUsertagManager().reload();
+                PowerRanks.getTablistConfigManager().reload();
+                
 				CacheManager.load(PowerRanks.fileLoc);
 				this.plugin.updateAllPlayersTABlist();
 
@@ -77,6 +81,9 @@ public class cmd_reload extends PowerCommand {
 								"commands." + commandName.toLowerCase() + ".config-start"));
 
 				PowerRanks.getConfigManager().reload();
+				PowerRanks.getLanguageManager().reload();
+				PowerRanks.getUsertagManager().reload();
+                PowerRanks.getTablistConfigManager().reload();
 
 				sender.sendMessage(
 						PowerRanks.getLanguageManager().getFormattedMessage(

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_tablist.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_tablist.java
@@ -1,9 +1,12 @@
 package nl.svenar.PowerRanks.Commands.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -11,6 +14,7 @@ import org.bukkit.entity.Player;
 import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Util.Util;
+import nl.svenar.common.utils.PRUtil;
 
 public class cmd_tablist extends PowerCommand {
 
@@ -22,45 +26,53 @@ public class cmd_tablist extends PowerCommand {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String commandName,
 			String[] args) {
+
+		if (args.length >= 1) {
+			if (args[0].equalsIgnoreCase("animation")) {
+				handleAnimationCommand(sender, cmd, commandLabel, commandName,
+						Arrays.copyOfRange(args, 1, args.length));
+			}
+		}
+
 		if (args.length == 2) {
 			if (args[0].equalsIgnoreCase("enable") || args[0].equalsIgnoreCase("disable")) {
 				boolean enable = args[0].equalsIgnoreCase("enable");
 
-                if (args[1].equalsIgnoreCase("tablist_sorting")) {
-                    sender.sendMessage(Util.powerFormatter(
-                        PowerRanks.getLanguageManager().getFormattedMessage(
-                                "commands." + commandName.toLowerCase() + ".state-changed"),
-                        ImmutableMap.<String, String>builder()
-                                .put("player", sender.getName())
-                                .put("config_target", "Tablist sorting")
-                                .put("old_state",
-                                        String.valueOf(PowerRanks.getTablistConfigManager()
-                                                .getBool("sorting.enabled", true)))
-                                .put("new_state", String.valueOf(enable))
-                                .build(),
-                        '[', ']'));
+				if (args[1].equalsIgnoreCase("tablist_sorting")) {
+					sender.sendMessage(Util.powerFormatter(
+							PowerRanks.getLanguageManager().getFormattedMessage(
+									"commands." + commandName.toLowerCase() + ".state-changed"),
+							ImmutableMap.<String, String>builder()
+									.put("player", sender.getName())
+									.put("config_target", "Tablist sorting")
+									.put("old_state",
+											String.valueOf(PowerRanks.getTablistConfigManager()
+													.getBool("sorting.enabled", true)))
+									.put("new_state", String.valueOf(enable))
+									.build(),
+							'[', ']'));
 
-                    PowerRanks.getTablistConfigManager().setBool("sorting.enabled", enable);
-                    PowerRanks.getInstance().getTablistManager().stop();
-                    PowerRanks.getInstance().getTablistManager().start();
+					PowerRanks.getTablistConfigManager().setBool("sorting.enabled", enable);
+					PowerRanks.getInstance().getTablistManager().stop();
+					PowerRanks.getInstance().getTablistManager().start();
 
-                } else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
-                    sender.sendMessage(Util.powerFormatter(
-                        PowerRanks.getLanguageManager().getFormattedMessage(
-                                "commands." + commandName.toLowerCase() + ".state-changed"),
-                        ImmutableMap.<String, String>builder()
-                                .put("player", sender.getName())
-                                .put("config_target", "Reverse tablist sorting")
-                                .put("old_state",
-                                        String.valueOf(PowerRanks.getTablistConfigManager()
-                                                .getBool("sorting.reverse", true)))
-                                .put("new_state", String.valueOf(enable))
-                                .build(),
-                        '[', ']'));
+				} else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
+					sender.sendMessage(Util.powerFormatter(
+							PowerRanks.getLanguageManager().getFormattedMessage(
+									"commands." + commandName.toLowerCase() + ".state-changed"),
+							ImmutableMap.<String, String>builder()
+									.put("player", sender.getName())
+									.put("config_target", "Reverse tablist sorting")
+									.put("old_state",
+											String.valueOf(PowerRanks.getTablistConfigManager()
+													.getBool("sorting.reverse", true)))
+									.put("new_state", String.valueOf(enable))
+									.build(),
+							'[', ']'));
 
-                    PowerRanks.getTablistConfigManager().setBool("sorting.reverse", enable);
-                    PowerRanks.getInstance().getTablistManager().stop();
-                    PowerRanks.getInstance().getTablistManager().start();
+					PowerRanks.getTablistConfigManager().setBool("sorting.reverse", enable);
+					PowerRanks.getInstance().getTablistManager().stop();
+					PowerRanks.getInstance().getTablistManager().start();
 
 				} else {
 					sender.sendMessage(
@@ -93,8 +105,8 @@ public class cmd_tablist extends PowerCommand {
 								'[', ']'));
 
 						PowerRanks.getTablistConfigManager().setInt("sorting.update-interval", time);
-                        PowerRanks.getInstance().getTablistManager().stop();
-                        PowerRanks.getInstance().getTablistManager().start();
+						PowerRanks.getInstance().getTablistManager().stop();
+						PowerRanks.getInstance().getTablistManager().start();
 					} catch (Exception e) {
 						sender.sendMessage(
 								PowerRanks.getLanguageManager().getFormattedMessage(
@@ -118,8 +130,8 @@ public class cmd_tablist extends PowerCommand {
 								'[', ']'));
 
 						PowerRanks.getTablistConfigManager().setInt("header-footer.update-interval", time);
-                        PowerRanks.getInstance().getTablistManager().stop();
-                        PowerRanks.getInstance().getTablistManager().start();
+						PowerRanks.getInstance().getTablistManager().stop();
+						PowerRanks.getInstance().getTablistManager().start();
 					} catch (Exception e) {
 						sender.sendMessage(
 								PowerRanks.getLanguageManager().getFormattedMessage(
@@ -136,6 +148,116 @@ public class cmd_tablist extends PowerCommand {
 		return false;
 	}
 
+	private void handleAnimationCommand(CommandSender sender, Command cmd, String commandLabel, String commandName,
+			String[] args) {
+
+		if (args.length >= 1) {
+			if (args[0].equalsIgnoreCase("list")) {
+				List<String> animationNames = PowerRanks.getTablistConfigManager().getKeys("header-footer.animations");
+
+				sender.sendMessage(ChatColor.BLUE + "===" + ChatColor.DARK_AQUA + "----------" + ChatColor.AQUA
+						+ plugin.getDescription().getName() + ChatColor.DARK_AQUA + "----------" + ChatColor.BLUE
+						+ "===");
+				sender.sendMessage(ChatColor.AQUA + "Animations (" + animationNames.size() + "):");
+				int index = 0;
+
+				for (String animationName : animationNames) {
+					index++;
+					sender.sendMessage(
+							ChatColor.DARK_GREEN + "#" + index + ". " + ChatColor.GRAY + animationName);
+				}
+				sender.sendMessage(ChatColor.BLUE + "===" + ChatColor.DARK_AQUA + "------------------------------"
+						+ ChatColor.BLUE + "===");
+
+			} else if (args[0].equalsIgnoreCase("create")) {
+				if (args.length == 2) {
+					String animationName = args[1];
+					if (PRUtil.containsIgnoreCase(
+							PowerRanks.getTablistConfigManager().getKeys("header-footer.animations"), animationName)) {
+						sender.sendMessage(
+								PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+										"commands." + commandName.toLowerCase() + ".animation.already-exists",
+										sender instanceof Player));
+						return;
+					}
+					PowerRanks.getTablistConfigManager().setKV("header-footer.animations" + animationName + ".delay",
+							20);
+					PowerRanks.getTablistConfigManager().setKV("header-footer.animations" + animationName + ".frames",
+							new ArrayList<String>());
+					sender.sendMessage(
+							PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+									"commands." + commandName.toLowerCase() + ".animation.created",
+									sender instanceof Player));
+				}
+
+			} else if (args[0].equalsIgnoreCase("delete")) {
+				if (args.length == 2) {
+					String animationName = args[1];
+					if (!PRUtil.containsIgnoreCase(
+							PowerRanks.getTablistConfigManager().getKeys("header-footer.animations"), animationName)) {
+						sender.sendMessage(
+								PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+										"commands." + commandName.toLowerCase() + ".animation.does-not-exists",
+										sender instanceof Player));
+						return;
+					}
+					PowerRanks.getTablistConfigManager().setKV("header-footer.animations" + animationName, null);
+					// TODO: take animation name case into account
+					sender.sendMessage(
+							PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+									"commands." + commandName.toLowerCase() + ".animation.deleted",
+									sender instanceof Player));
+				}
+
+			} else if (args[0].equalsIgnoreCase("delay")) {
+				if (args.length == 3) {
+					try {
+						String animationName = args[1];
+						if (!PRUtil.containsIgnoreCase(
+								PowerRanks.getTablistConfigManager().getKeys("header-footer.animations"),
+								animationName)) {
+							sender.sendMessage(
+									PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+											"commands." + commandName.toLowerCase() + ".animation.unknown-animation",
+											sender instanceof Player));
+							return;
+						}
+						int time = Integer.parseInt(args[2]);
+
+						sender.sendMessage(Util.powerFormatter(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".state-changed"),
+								ImmutableMap.<String, String>builder()
+										.put("player", sender.getName())
+										.put("config_target", "Tablist animation update interval")
+										.put("old_state",
+												String.valueOf(PowerRanks.getTablistConfigManager()
+														.getInt("header-footer.animations" + animationName + ".delay",
+																20)))
+										.put("new_state", String.valueOf(time))
+										.build(),
+								'[', ']'));
+
+						PowerRanks.getTablistConfigManager()
+								.setInt("header-footer.animations" + animationName + ".delay", time);
+						PowerRanks.getInstance().getTablistManager().stop();
+						PowerRanks.getInstance().getTablistManager().start();
+					} catch (Exception e) {
+						sender.sendMessage(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".numbers-only"));
+					}
+				}
+
+			}
+		} else {
+			sender.sendMessage(
+					PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+							"commands." + commandName.toLowerCase() + ".animation.arguments",
+							sender instanceof Player));
+		}
+	}
+
 	public ArrayList<String> tabCompleteEvent(CommandSender sender, String[] args) {
 		ArrayList<String> tabcomplete = new ArrayList<String>();
 
@@ -143,6 +265,7 @@ public class cmd_tablist extends PowerCommand {
 			tabcomplete.add("enable");
 			tabcomplete.add("disable");
 			tabcomplete.add("set");
+			tabcomplete.add("animation");
 		}
 
 		if (args.length == 2) {
@@ -150,9 +273,14 @@ public class cmd_tablist extends PowerCommand {
 				tabcomplete.add("tablist_sorting");
 				tabcomplete.add("reverse_tablist_sorting");
 			}
-		}
 
-		if (args.length == 2) {
+			if (args[0].equalsIgnoreCase("animation")) {
+				tabcomplete.add("list");
+				tabcomplete.add("create");
+				tabcomplete.add("delete");
+				tabcomplete.add("delay");
+			}
+
 			if (args[0].equalsIgnoreCase("set")) {
 				tabcomplete.add("sorting_update_interval");
 				tabcomplete.add("header_footer_update_interval");
@@ -160,27 +288,33 @@ public class cmd_tablist extends PowerCommand {
 		}
 
 		if (args.length == 3) {
-			if (args[1].equalsIgnoreCase("sorting_update_interval")) {
-				tabcomplete.add("1");
-				tabcomplete.add("5");
-				tabcomplete.add("10");
+			if (args[0].equalsIgnoreCase("set")) {
+				if (args[1].equalsIgnoreCase("sorting_update_interval")) {
+					tabcomplete.add("1");
+					tabcomplete.add("5");
+					tabcomplete.add("10");
+				}
+
+				if (args[1].equalsIgnoreCase("header_footer_update_interval")) {
+					tabcomplete.add("1");
+					tabcomplete.add("5");
+					tabcomplete.add("20");
+					tabcomplete.add("100");
+					tabcomplete.add("200");
+				}
 			}
 
-			if (args[1].equalsIgnoreCase("header_footer_update_interval")) {
-				tabcomplete.add("1");
-				tabcomplete.add("5");
-				tabcomplete.add("20");
-				tabcomplete.add("100");
-				tabcomplete.add("200");
-			}
-		}
-
-		if (args.length == 3) {
-			if (args[1].equalsIgnoreCase("playtime_update_interval")) {
-				tabcomplete.add("1");
-				tabcomplete.add("5");
-				tabcomplete.add("10");
-				tabcomplete.add("60");
+			if (args[0].equalsIgnoreCase("animation")) {
+				if (args[1].equalsIgnoreCase("delete")) {
+					for (String key : PowerRanks.getTablistConfigManager().getKeys("header-footer.animations")) {
+						tabcomplete.add(key);
+					}
+				}
+				if (args[1].equalsIgnoreCase("delay")) {
+					tabcomplete.add("1");
+					tabcomplete.add("5");
+					tabcomplete.add("10");
+				}
 			}
 		}
 

--- a/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_tablist.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/core/cmd_tablist.java
@@ -1,0 +1,189 @@
+package nl.svenar.PowerRanks.Commands.core;
+
+import java.util.ArrayList;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import nl.svenar.PowerRanks.PowerRanks;
+import nl.svenar.PowerRanks.Commands.PowerCommand;
+import nl.svenar.PowerRanks.Util.Util;
+
+public class cmd_tablist extends PowerCommand {
+
+	public cmd_tablist(PowerRanks plugin, String command_name, COMMAND_EXECUTOR ce) {
+		super(plugin, command_name, ce);
+		this.setCommandPermission("powerranks.cmd." + command_name.toLowerCase());
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String commandName,
+			String[] args) {
+		if (args.length == 2) {
+			if (args[0].equalsIgnoreCase("enable") || args[0].equalsIgnoreCase("disable")) {
+				boolean enable = args[0].equalsIgnoreCase("enable");
+
+                if (args[1].equalsIgnoreCase("tablist_sorting")) {
+                    sender.sendMessage(Util.powerFormatter(
+                        PowerRanks.getLanguageManager().getFormattedMessage(
+                                "commands." + commandName.toLowerCase() + ".state-changed"),
+                        ImmutableMap.<String, String>builder()
+                                .put("player", sender.getName())
+                                .put("config_target", "Tablist sorting")
+                                .put("old_state",
+                                        String.valueOf(PowerRanks.getTablistConfigManager()
+                                                .getBool("sorting.enabled", true)))
+                                .put("new_state", String.valueOf(enable))
+                                .build(),
+                        '[', ']'));
+
+                    PowerRanks.getTablistConfigManager().setBool("sorting.enabled", enable);
+                    PowerRanks.getInstance().getTablistManager().stop();
+                    PowerRanks.getInstance().getTablistManager().start();
+
+                } else if (args[1].equalsIgnoreCase("reverse_tablist_sorting")) {
+                    sender.sendMessage(Util.powerFormatter(
+                        PowerRanks.getLanguageManager().getFormattedMessage(
+                                "commands." + commandName.toLowerCase() + ".state-changed"),
+                        ImmutableMap.<String, String>builder()
+                                .put("player", sender.getName())
+                                .put("config_target", "Reverse tablist sorting")
+                                .put("old_state",
+                                        String.valueOf(PowerRanks.getTablistConfigManager()
+                                                .getBool("sorting.reverse", true)))
+                                .put("new_state", String.valueOf(enable))
+                                .build(),
+                        '[', ']'));
+
+                    PowerRanks.getTablistConfigManager().setBool("sorting.reverse", enable);
+                    PowerRanks.getInstance().getTablistManager().stop();
+                    PowerRanks.getInstance().getTablistManager().start();
+
+				} else {
+					sender.sendMessage(
+							PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+									"commands." + commandName.toLowerCase() + ".arguments", sender instanceof Player));
+				}
+			} else {
+				sender.sendMessage(
+						PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+								"commands." + commandName.toLowerCase() + ".arguments", sender instanceof Player));
+			}
+		} else if (args.length == 3) {
+			if (args[0].equalsIgnoreCase("set")) {
+
+				if (args[1].equalsIgnoreCase("sorting_update_interval")) {
+					try {
+						int time = Integer.parseInt(args[2]);
+
+						sender.sendMessage(Util.powerFormatter(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".state-changed"),
+								ImmutableMap.<String, String>builder()
+										.put("player", sender.getName())
+										.put("config_target", "Player playtime update interval")
+										.put("old_state",
+												String.valueOf(PowerRanks.getTablistConfigManager()
+														.getInt("sorting.update-interval", 60)))
+										.put("new_state", String.valueOf(time))
+										.build(),
+								'[', ']'));
+
+						PowerRanks.getTablistConfigManager().setInt("sorting.update-interval", time);
+                        PowerRanks.getInstance().getTablistManager().stop();
+                        PowerRanks.getInstance().getTablistManager().start();
+					} catch (Exception e) {
+						sender.sendMessage(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".numbers-only"));
+					}
+				} else if (args[1].equalsIgnoreCase("header_footer_update_interval")) {
+					try {
+						int time = Integer.parseInt(args[2]);
+
+						sender.sendMessage(Util.powerFormatter(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".state-changed"),
+								ImmutableMap.<String, String>builder()
+										.put("player", sender.getName())
+										.put("config_target", "Player playtime update interval")
+										.put("old_state",
+												String.valueOf(PowerRanks.getTablistConfigManager()
+														.getInt("header-footer.update-interval", 60)))
+										.put("new_state", String.valueOf(time))
+										.build(),
+								'[', ']'));
+
+						PowerRanks.getTablistConfigManager().setInt("header-footer.update-interval", time);
+                        PowerRanks.getInstance().getTablistManager().stop();
+                        PowerRanks.getInstance().getTablistManager().start();
+					} catch (Exception e) {
+						sender.sendMessage(
+								PowerRanks.getLanguageManager().getFormattedMessage(
+										"commands." + commandName.toLowerCase() + ".numbers-only"));
+					}
+				}
+			}
+		} else {
+			sender.sendMessage(
+					PowerRanks.getLanguageManager().getFormattedUsageMessage(commandLabel, commandName,
+							"commands." + commandName.toLowerCase() + ".arguments", sender instanceof Player));
+		}
+
+		return false;
+	}
+
+	public ArrayList<String> tabCompleteEvent(CommandSender sender, String[] args) {
+		ArrayList<String> tabcomplete = new ArrayList<String>();
+
+		if (args.length == 1) {
+			tabcomplete.add("enable");
+			tabcomplete.add("disable");
+			tabcomplete.add("set");
+		}
+
+		if (args.length == 2) {
+			if (args[0].equalsIgnoreCase("enable") || args[0].equalsIgnoreCase("disable")) {
+				tabcomplete.add("tablist_sorting");
+				tabcomplete.add("reverse_tablist_sorting");
+			}
+		}
+
+		if (args.length == 2) {
+			if (args[0].equalsIgnoreCase("set")) {
+				tabcomplete.add("sorting_update_interval");
+				tabcomplete.add("header_footer_update_interval");
+			}
+		}
+
+		if (args.length == 3) {
+			if (args[1].equalsIgnoreCase("sorting_update_interval")) {
+				tabcomplete.add("1");
+				tabcomplete.add("5");
+				tabcomplete.add("10");
+			}
+
+			if (args[1].equalsIgnoreCase("header_footer_update_interval")) {
+				tabcomplete.add("1");
+				tabcomplete.add("5");
+				tabcomplete.add("20");
+				tabcomplete.add("100");
+				tabcomplete.add("200");
+			}
+		}
+
+		if (args.length == 3) {
+			if (args[1].equalsIgnoreCase("playtime_update_interval")) {
+				tabcomplete.add("1");
+				tabcomplete.add("5");
+				tabcomplete.add("10");
+				tabcomplete.add("60");
+			}
+		}
+
+		return tabcomplete;
+	}
+}

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_addownrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_addownrank.java
@@ -15,6 +15,7 @@ import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_addownrank extends PowerCommand {
@@ -44,7 +45,9 @@ public class cmd_addownrank extends PowerCommand {
 				PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(target_rank));
 				PRPlayer targetPlayer = CacheManager.getPlayer(sender.getName());
 				if (rank != null && targetPlayer != null) {
-					targetPlayer.addRank(rank.getName());
+					PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+					targetPlayer.addRank(playerRank);
+
 
                     if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
                         PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_addrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_addrank.java
@@ -15,6 +15,7 @@ import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_addrank extends PowerCommand {
@@ -44,7 +45,8 @@ public class cmd_addrank extends PowerCommand {
 				PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(target_rank));
 				PRPlayer targetPlayer = CacheManager.getPlayer(args[0]);
 				if (rank != null && targetPlayer != null) {
-					targetPlayer.addRank(rank.getName());
+					PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+					targetPlayer.addRank(playerRank);
 
                     if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
                         PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_checkrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_checkrank.java
@@ -14,6 +14,7 @@ import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Util.Util;
+import nl.svenar.common.structure.PRPlayerRank;
 
 public class cmd_checkrank extends PowerCommand {
 
@@ -28,8 +29,11 @@ public class cmd_checkrank extends PowerCommand {
 		if (args.length == 0) {
 			if (sender instanceof Player) {
 				// String rankname = this.users.getPrimaryRank();
-				List<String> playerRanks = CacheManager.getPlayer(((Player) sender).getUniqueId().toString())
-						.getRanks();
+				List<String> playerRanks = new ArrayList<>();
+				for (PRPlayerRank rank : CacheManager.getPlayer(((Player) sender).getUniqueId().toString())
+						.getRanks()) {
+					playerRanks.add(rank.getName());
+				}
 				if (playerRanks.size() > 0) {
 					sender.sendMessage(Util.powerFormatter(
 							PowerRanks.getLanguageManager()
@@ -56,8 +60,11 @@ public class cmd_checkrank extends PowerCommand {
 		} else if (args.length == 1) {
 			Player targetPlayer = Util.getPlayerByName(args[0]);
 			if (targetPlayer != null) {
-				List<String> playerRanks = CacheManager.getPlayer(targetPlayer.getUniqueId().toString())
-						.getRanks();
+				List<String> playerRanks = new ArrayList<>();
+				for (PRPlayerRank rank : CacheManager.getPlayer(((Player) sender).getUniqueId().toString())
+						.getRanks()) {
+					playerRanks.add(rank.getName());
+				}
 				if (playerRanks.size() > 0) {
 					sender.sendMessage(Util.powerFormatter(
 							PowerRanks.getLanguageManager()

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_delrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_delrank.java
@@ -1,6 +1,7 @@
 package nl.svenar.PowerRanks.Commands.player;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -15,6 +16,7 @@ import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_delrank extends PowerCommand {
@@ -35,7 +37,8 @@ public class cmd_delrank extends PowerCommand {
 
 			boolean commandAllowed = false;
 			if (sender instanceof Player) {
-				commandAllowed = sender.hasPermission("powerranks.cmd." + commandName.toLowerCase() + "." + target_rank);
+				commandAllowed = sender
+						.hasPermission("powerranks.cmd." + commandName.toLowerCase() + "." + target_rank);
 			} else {
 				commandAllowed = true;
 			}
@@ -44,12 +47,22 @@ public class cmd_delrank extends PowerCommand {
 				PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(target_rank));
 				PRPlayer targetPlayer = CacheManager.getPlayer(args[0]);
 				if (rank != null && targetPlayer != null) {
-					targetPlayer.removeRank(rank.getName());
+					PRPlayerRank playerRank = null;
+					for (PRPlayerRank targetPlayerRank : targetPlayer.getRanks()) {
+						if (targetPlayerRank.getName().equals(rank.getName())) {
+							playerRank = targetPlayerRank;
+							break;
+						}
+					}
+					if (playerRank != null) {
+						targetPlayer.removeRank(playerRank);
+					}
 
-                    if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
-                        PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));
-                        PowerRanks.getInstance().getTablistManager().updateSorting(Bukkit.getPlayer(targetPlayer.getUUID()));
-                    }
+					if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
+						PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));
+						PowerRanks.getInstance().getTablistManager()
+								.updateSorting(Bukkit.getPlayer(targetPlayer.getUUID()));
+					}
 
 					sender.sendMessage(Util.powerFormatter(
 							PowerRanks.getLanguageManager()
@@ -109,7 +122,11 @@ public class cmd_delrank extends PowerCommand {
 		if (args.length == 2) {
 			Player target_player = Util.getPlayerByName(args[0]);
 			if (target_player != null) {
-				for (String rank : CacheManager.getPlayer(target_player.getUniqueId().toString()).getRanks()) {
+				List<String> ranks = new ArrayList<>();
+				for (PRPlayerRank rank : CacheManager.getPlayer(target_player.getUniqueId().toString()).getRanks()) {
+					ranks.add(rank.getName());
+				}
+				for (String rank : ranks) {
 					tabcomplete.add(rank);
 				}
 			}

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setownrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setownrank.java
@@ -15,6 +15,7 @@ import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_setownrank extends PowerCommand {
@@ -35,7 +36,8 @@ public class cmd_setownrank extends PowerCommand {
 
 			boolean commandAllowed = false;
 			if (sender instanceof Player) {
-				commandAllowed = sender.hasPermission("powerranks.cmd." + commandName.toLowerCase() + "." + target_rank);
+				commandAllowed = sender
+						.hasPermission("powerranks.cmd." + commandName.toLowerCase() + "." + target_rank);
 			} else {
 				commandAllowed = true;
 			}
@@ -44,12 +46,14 @@ public class cmd_setownrank extends PowerCommand {
 				PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(target_rank));
 				PRPlayer targetPlayer = CacheManager.getPlayer(sender.getName());
 				if (rank != null && targetPlayer != null) {
-					targetPlayer.setRank(rank.getName());
+					PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+					targetPlayer.setRank(playerRank);
 
-                    if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
-                        PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));
-                        PowerRanks.getInstance().getTablistManager().updateSorting(Bukkit.getPlayer(targetPlayer.getUUID()));
-                    }
+					if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
+						PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));
+						PowerRanks.getInstance().getTablistManager()
+								.updateSorting(Bukkit.getPlayer(targetPlayer.getUUID()));
+					}
 
 					sender.sendMessage(Util.powerFormatter(
 							PowerRanks.getLanguageManager()

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setrank.java
@@ -16,6 +16,7 @@ import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.common.structure.PRPermission;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class cmd_setrank extends PowerCommand {
@@ -49,14 +50,22 @@ public class cmd_setrank extends PowerCommand {
 				PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(target_rank));
 				PRPlayer targetPlayer = CacheManager.getPlayer(args[0]);
 				if (rank != null && targetPlayer != null) {
-					targetPlayer.setRank(rank.getName());
+					PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+					targetPlayer.setRank(playerRank);
 
                     if (Bukkit.getPlayer(targetPlayer.getUUID()) != null) {
                         PowerRanks.getInstance().updateTablistName(Bukkit.getPlayer(targetPlayer.getUUID()));
                         PowerRanks.getInstance().getTablistManager().updateSorting(Bukkit.getPlayer(targetPlayer.getUUID()));
                     }
 
-					if (targetPlayer.getRanks().contains(rank.getName())) {
+					boolean hasRank = false;
+					for (PRPlayerRank playerrank : targetPlayer.getRanks()) {
+						if (playerrank.getName().equals(rank.getName())) {
+							hasRank = true;
+							break;
+						}
+					}
+					if (hasRank) {
 						sender.sendMessage(Util.powerFormatter(
 								PowerRanks.getLanguageManager()
 										.getFormattedMessage(

--- a/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setrank.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/player/cmd_setrank.java
@@ -94,8 +94,8 @@ public class cmd_setrank extends PowerCommand {
 							.getFormattedMessage(
 									"commands." + commandName.toLowerCase() + ".failed-executor"),
 					ImmutableMap.<String, String>builder()
-							.put("player", targetPlayer.getName())
-							.put("rank", rank.getName())
+							.put("player", targetPlayer == null ? args[0] : targetPlayer.getName())
+							.put("rank", rank == null ? args[1] : rank.getName())
 							.build(),
 					'[', ']'));
 				}

--- a/src/main/java/nl/svenar/PowerRanks/Commands/usertags/cmd_addusertag.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/usertags/cmd_addusertag.java
@@ -10,6 +10,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import nl.svenar.PowerRanks.PowerRanks;
+import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
@@ -122,9 +123,15 @@ public class cmd_addusertag extends PowerCommand {
 		}
 
 		if (args.length == 2) {
-			for (String tag : this.users.getUserTags()) {
-				tabcomplete.add(tag);
-			}
+            for (String tag : this.users.getUserTags()) {
+                tabcomplete.add(tag);
+            }
+            Player target_player = Util.getPlayerByName(args[0]);
+			if (target_player != null) {
+                for (String tag : CacheManager.getPlayer(target_player.getUniqueId().toString()).getUsertags()) {
+                    tabcomplete.remove(tag);
+                }
+            }
 		}
 
 		return tabcomplete;

--- a/src/main/java/nl/svenar/PowerRanks/Commands/usertags/cmd_delusertag.java
+++ b/src/main/java/nl/svenar/PowerRanks/Commands/usertags/cmd_delusertag.java
@@ -10,6 +10,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import nl.svenar.PowerRanks.PowerRanks;
+import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Commands.PowerCommand;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.Util.Util;
@@ -122,8 +123,11 @@ public class cmd_delusertag extends PowerCommand {
 		}
 
 		if (args.length == 2) {
-			for (String tag : this.users.getUserTags()) {
-				tabcomplete.add(tag);
+            Player target_player = Util.getPlayerByName(args[0]);
+			if (target_player != null) {
+                for (String tag : CacheManager.getPlayer(target_player.getUniqueId().toString()).getUsertags()) {
+                    tabcomplete.add(tag);
+                }
 			}
 		}
 

--- a/src/main/java/nl/svenar/PowerRanks/Data/BungeecordManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/BungeecordManager.java
@@ -1,0 +1,179 @@
+package nl.svenar.PowerRanks.Data;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Map.Entry;
+
+import org.bukkit.scheduler.BukkitRunnable;
+
+import nl.svenar.PowerRanks.PowerRanks;
+import nl.svenar.PowerRanks.Cache.CacheManager;
+import nl.svenar.common.storage.provided.MySQLStorageManager;
+import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRRank;
+import nl.svenar.common.utils.PRUtil;
+
+public class BungeecordManager {
+
+    private UUID serverUUID;
+    private ArrayList<UUID> onlineServers = new ArrayList<UUID>();
+    private boolean ready = false;
+    private BukkitRunnable mainTask;
+    private int ranksHashcode, playersHashcode, lastRanksHashcode, lastPlayersHashcode;
+
+    public BungeecordManager(PowerRanks powerRanks) {
+        serverUUID = UUID.fromString(PowerRanks.getConfigManager().getString("bungeecord.uuid", UUID.randomUUID().toString()));
+    }
+
+    public void start() {
+        if (!PowerRanks.getConfigManager().getBool("bungeecord.enabled", false)) {
+            return;
+        }
+
+        if (!(CacheManager.getStorageManager() instanceof MySQLStorageManager)) {
+            PowerRanks.log.severe("");
+            PowerRanks.log.severe("=== ----------------------------- ===");
+            PowerRanks.log.severe("               WARNING               ");
+            PowerRanks.log.severe("     Bungeecord is enabled, but      ");
+            PowerRanks.log.severe("  storage type is not set to MYSQL!  ");
+            PowerRanks.log.severe("");
+            PowerRanks.log.severe("Bungeecord functionality is disabled!");
+            PowerRanks.log.severe("=== ----------------------------- ===");
+            PowerRanks.log.severe("");
+            return;
+        }
+        this.ready = true;
+        PowerRanks.log.info("Setting up Bungeecord with ID " + this.serverUUID.toString());
+
+        CacheManager.postDBMessage(UUID.fromString("00000000-0000-0000-0000-000000000000"), this.serverUUID.toString(), "online");
+
+        this.updateHashes();
+        this.lastRanksHashcode = this.ranksHashcode;
+        this.lastPlayersHashcode = this.playersHashcode;
+
+        mainTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Instant startTime = Instant.now();
+
+                for (Entry<String, String> e : CacheManager.getDBBroadcastMessages().entrySet()) {
+                    UUID targetUUID = UUID.fromString(e.getKey().split("\\.")[1]);
+                    if (e.getValue().equalsIgnoreCase("online") && !targetUUID.toString().equals(serverUUID.toString())) {
+                        if (!onlineServers.contains(targetUUID)) {
+                            onlineServers.add(targetUUID);
+                        }
+                    } else {
+                        if (onlineServers.contains(targetUUID)) {
+                            onlineServers.remove(targetUUID);
+                        }
+                    }
+                }
+
+                updateHashes();
+                boolean rankHashChanged = lastRanksHashcode != ranksHashcode;
+                boolean playerHashChanged = lastPlayersHashcode != playersHashcode;
+
+                if (rankHashChanged || playerHashChanged) {
+                    CacheManager.save();
+                }
+
+                if (rankHashChanged) {
+                    for (UUID remoteServer : onlineServers) {
+                        CacheManager.postDBMessage(remoteServer, "update.ranks", String.valueOf(Instant.now().getEpochSecond()));
+                    }
+                }
+
+                if (playerHashChanged) {
+                    for (UUID remoteServer : onlineServers) {
+                        CacheManager.postDBMessage(remoteServer, "update.players", String.valueOf(Instant.now().getEpochSecond()));
+                    }
+                }
+
+                boolean doReloadData = false;
+                for (Entry<String, String> newMessage : CacheManager.getDBMessages(serverUUID).entrySet()) {
+                    String command = newMessage.getKey().split("\\.")[1];
+
+                    switch(command.toLowerCase()) {
+                        case "update":
+                            String updateType = newMessage.getKey().split("\\.")[2];
+
+                            switch(updateType.toLowerCase()) {
+                                case "ranks":
+                                    doReloadData = true;
+                                    break;
+                                
+                                case "players":
+                                    doReloadData = true;
+                                    break;
+                                
+                                default:
+                                    break;
+                            }
+                            break;
+                        
+                        default:
+                            break;
+                    }
+
+                    CacheManager.removeDBMessage(serverUUID, newMessage.getKey().replaceAll(serverUUID.toString() + ".", ""));
+                }
+
+                if (doReloadData) {
+                    PowerRanks.log.warning("Reloading data from database!");
+
+                    CacheManager.load(PowerRanks.fileLoc);
+                    PowerRanks.getInstance().updateAllPlayersTABlist();
+
+                    updateHashes();
+                    lastRanksHashcode = ranksHashcode;
+                    lastPlayersHashcode = playersHashcode;
+                }
+
+                PowerRanksVerbose.log("task", "Running task bungeecord mainTask in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+            }
+        };
+        mainTask.runTaskTimer(
+            PowerRanks.getInstance(),
+            0,
+            20 * 5
+        );
+    }
+
+    public void stop() {
+        if (!PowerRanks.getConfigManager().getBool("bungeecord.enabled", false)) {
+            return;
+        }
+
+        if (!(CacheManager.getStorageManager() instanceof MySQLStorageManager)) {
+            return;
+        }
+        this.ready = false;
+
+        CacheManager.postDBMessage(UUID.fromString("00000000-0000-0000-0000-000000000000"), serverUUID.toString(), "offline");
+    }
+    
+    public boolean isReady() {
+        return this.ready;
+    }
+
+    public int getServerCount() {
+        return this.onlineServers.size();
+    }
+
+    private void updateHashes() {
+        this.lastRanksHashcode = this.ranksHashcode;
+        this.lastPlayersHashcode = this.playersHashcode;
+
+        this.ranksHashcode = 17;
+        for (PRRank rank : PRUtil.sortRanksByWeight(CacheManager.getRanks())) {
+            ranksHashcode = 31 * ranksHashcode + (rank != null ? rank.hashCode() : 0);
+        }
+
+        this.playersHashcode = 0;
+        for (PRPlayer player : CacheManager.getPlayers()) {
+            playersHashcode += player.hashCode();
+        }
+    }
+}

--- a/src/main/java/nl/svenar/PowerRanks/Data/Messages.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/Messages.java
@@ -29,6 +29,7 @@ import nl.svenar.PowerRanks.addons.PowerRanksAddon;
 import nl.svenar.PowerRanks.addons.PowerRanksPlayer;
 import nl.svenar.common.structure.PRPermission;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -329,7 +330,13 @@ public class Messages {
 				: String.format("%02d:%02d:%02d", hours, minutes, seconds);
 
 		String formatted_ranks = "";
-		for (String rankname : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
+
+		for (String rankname : ranknames) {
 			formatted_ranks += rankname + " ";
 		}
 		if (formatted_ranks.endsWith(" ")) {
@@ -416,7 +423,10 @@ public class Messages {
 
 		String format = PowerRanks.getConfigManager().getString("chat.format", "");
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {

--- a/src/main/java/nl/svenar/PowerRanks/Data/Messages.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/Messages.java
@@ -93,6 +93,10 @@ public class Messages {
 		}
 		sender.sendMessage(ChatColor.GREEN + "RGB colors: "
 				+ (hex_color_supported ? ChatColor.DARK_GREEN + "" : ChatColor.DARK_RED + "un") + "supported");
+        sender.sendMessage(ChatColor.GREEN + "Bungeecord: "
+                + (PowerRanks.getInstance().getBungeecordManager().isReady() ? ChatColor.DARK_GREEN + "enabled" : ChatColor.DARK_RED + "disabled"));
+        sender.sendMessage(ChatColor.GREEN + "- Connected servers: "
+                + ChatColor.DARK_GREEN + PowerRanks.getInstance().getBungeecordManager().getServerCount());
 
 		sender.sendMessage(ChatColor.GREEN + "Plugin hooks:");
 		sender.sendMessage(ChatColor.GREEN + "- Vault Economy: "

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistAnimation.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistAnimation.java
@@ -1,0 +1,35 @@
+package nl.svenar.PowerRanks.Data;
+
+import java.util.ArrayList;
+
+public class TablistAnimation {
+
+    private int delay = 0;
+    private int tick = 0;
+    private int index = 0;
+    private ArrayList<String> frames = new ArrayList<String>();
+
+    public void setDelay(int delay) {
+        this.delay = delay;
+    }
+
+    public void setFrames(ArrayList<String> frames) {
+        this.frames = frames;
+    }
+
+    public void update() {
+        if (tick >= delay) {
+            tick = 0;
+            index++;
+            if (index >= frames.size()) {
+                index = 0;
+            }
+        }
+        tick++;
+    }
+
+    public String getCurrentFrame() {
+        return frames.get(index);
+    }
+    
+}

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -278,9 +278,11 @@ public class TablistManager {
         PRRank playerHighestRank = null;
         for (String rankname: targetPlayer.getRanks()) {
             PRRank rank = CacheManager.getRank(rankname);
-            if (rank.getWeight() > playerHighestRankWeight) {
-                playerHighestRankWeight = rank.getWeight();
-                playerHighestRank = rank;
+            if (rank != null) {
+                if (rank.getWeight() > playerHighestRankWeight) {
+                    playerHighestRankWeight = rank.getWeight();
+                    playerHighestRank = rank;
+                }
             }
         }
         if (playerHighestWeight.get(player.getUniqueId()) != playerHighestRankWeight) {

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 import org.bukkit.Bukkit;
@@ -25,7 +26,7 @@ import org.bukkit.scoreboard.Team;
 public class TablistManager {
 
     private Scoreboard scoreboard;
-    private HashMap <UUID, Integer> playerHighestWeight = new HashMap <UUID, Integer>();
+    private HashMap<UUID, Integer> playerHighestWeight = new HashMap<UUID, Integer>();
     private int numRanks = -1;
     private int totalWeight = -1;
     private BukkitRunnable sortingTask, headerFooterTask;
@@ -34,7 +35,8 @@ public class TablistManager {
     private HashMap<String, TablistAnimation> tablistAnimations = new HashMap<String, TablistAnimation>();
     private int verboseLogInterval = 0;
 
-    public TablistManager() {}
+    public TablistManager() {
+    }
 
     public void start() {
         PowerRanksVerbose.log("TablistSort", "Initializing");
@@ -44,7 +46,7 @@ public class TablistManager {
         if (PowerRanks.getTablistConfigManager().getBool("header-footer.enabled", true)) {
             setupHeaderFooter();
         }
-            
+
     }
 
     private void setupSorting() {
@@ -56,10 +58,11 @@ public class TablistManager {
                 if (scoreboard == null) {
                     try {
                         scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-                        for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
                             onPlayerJoin(player);
                         }
-                    } catch (Exception e) {}
+                    } catch (Exception e) {
+                    }
                 }
 
                 if (scoreboard == null) {
@@ -68,9 +71,8 @@ public class TablistManager {
 
                 boolean doUpdateRanks = false;
 
-                List <PRRank> sortedRanks = PRUtil.sortRanksByWeight(
-                    CacheManager.getRanks()
-                );
+                List<PRRank> sortedRanks = PRUtil.sortRanksByWeight(
+                        CacheManager.getRanks());
                 if (!PowerRanks.getTablistConfigManager().getBool("sorting.reverse", false)) {
                     Collections.reverse(sortedRanks);
                 }
@@ -81,7 +83,7 @@ public class TablistManager {
                 }
 
                 int newTotalRankWeight = 0;
-                for (PRRank rank: sortedRanks) {
+                for (PRRank rank : sortedRanks) {
                     newTotalRankWeight += rank.getWeight();
                 }
                 if (totalWeight != newTotalRankWeight) {
@@ -91,45 +93,51 @@ public class TablistManager {
 
                 if (doUpdateRanks) {
                     for (Team team : scoreboard.getTeams()) {
-                        for (String entry: team.getEntries()) {
+                        for (String entry : team.getEntries()) {
                             team.removeEntry(entry);
                         }
                         team.unregister();
                     }
                     for (int i = 0; i < sortedRanks.size(); i++) {
                         scoreboard.registerNewTeam(i + "-" + sortedRanks.get(i).getName());
-                        PowerRanksVerbose.log("TablistSort", "Creating new scoreboard team: " + i + "-" + sortedRanks.get(i).getName());
+                        PowerRanksVerbose.log("TablistSort",
+                                "Creating new scoreboard team: " + i + "-" + sortedRanks.get(i).getName());
                     }
                 }
 
-                for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                for (Player player : Bukkit.getServer().getOnlinePlayers()) {
                     updateSorting(player);
                 }
 
-                PowerRanksVerbose.log("task", "Running task sort tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+                PowerRanksVerbose.log("task",
+                        "Running task sort tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
             }
         };
         sortingTask.runTaskTimer(
-            PowerRanks.getInstance(),
-            0,
-            PowerRanks.getInstance().TASK_TPS * PowerRanks.getTablistConfigManager().getInt("sorting.update-interval", 1)
-        );
+                PowerRanks.getInstance(),
+                0,
+                PowerRanks.getInstance().TASK_TPS
+                        * PowerRanks.getTablistConfigManager().getInt("sorting.update-interval", 1));
     }
 
     @SuppressWarnings("unchecked")
     private void setupHeaderFooter() {
-        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.header", new ArrayList<String>())) {
+        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.header",
+                new ArrayList<String>())) {
             headerLines.add(line);
         }
 
-        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.footer", new ArrayList<String>())) {
+        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.footer",
+                new ArrayList<String>())) {
             footerLines.add(line);
         }
 
         for (String animationName : PowerRanks.getTablistConfigManager().getKeys("header-footer.animations")) {
             TablistAnimation newAnimation = new TablistAnimation();
-            newAnimation.setDelay(PowerRanks.getTablistConfigManager().getInt("header-footer.animations." + animationName + ".delay", 1));
-            newAnimation.setFrames((ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.animations." + animationName + ".frames", new ArrayList<String>()));
+            newAnimation.setDelay(PowerRanks.getTablistConfigManager()
+                    .getInt("header-footer.animations." + animationName + ".delay", 1));
+            newAnimation.setFrames((ArrayList<String>) PowerRanks.getTablistConfigManager()
+                    .getList("header-footer.animations." + animationName + ".frames", new ArrayList<String>()));
             tablistAnimations.put(animationName, newAnimation);
         }
 
@@ -151,17 +159,17 @@ public class TablistManager {
                 }
 
                 if (verboseLogInterval > 100) {
-                    PowerRanksVerbose.log("task", "Running task header/footer tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+                    PowerRanksVerbose.log("task", "Running task header/footer tablist in "
+                            + Duration.between(startTime, Instant.now()).toMillis() + "ms");
                     verboseLogInterval = 0;
                 }
                 verboseLogInterval++;
             }
         };
         headerFooterTask.runTaskTimer(
-            PowerRanks.getInstance(),
-            0,
-            PowerRanks.getTablistConfigManager().getInt("header-footer.update-interval", 1)
-        );
+                PowerRanks.getInstance(),
+                0,
+                PowerRanks.getTablistConfigManager().getInt("header-footer.update-interval", 1));
     }
 
     private String formatAnimations(String line) {
@@ -188,7 +196,7 @@ public class TablistManager {
                         replacement = animation.getCurrentFrame();
                     }
                     break;
-                
+
                 default:
                     break;
             }
@@ -229,7 +237,7 @@ public class TablistManager {
     }
 
     public void stop() {
-        for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
             player.setPlayerListHeader(null);
             player.setPlayerListFooter(null);
         }
@@ -238,7 +246,7 @@ public class TablistManager {
         footerLines = new ArrayList<String>();
         tablistAnimations = new HashMap<String, TablistAnimation>();
 
-        for (Entry<UUID,Integer> entry : playerHighestWeight.entrySet()) {
+        for (Entry<UUID, Integer> entry : playerHighestWeight.entrySet()) {
             entry.setValue(Integer.MIN_VALUE);
         }
 
@@ -275,11 +283,16 @@ public class TablistManager {
         }
 
         PRPlayer targetPlayer = CacheManager.getPlayer(
-            player.getUniqueId().toString()
-        );
+                player.getUniqueId().toString());
         int playerHighestRankWeight = Integer.MIN_VALUE;
         PRRank playerHighestRank = null;
-        for (String rankname: targetPlayer.getRanks()) {
+
+        List<String> ranknames = new ArrayList<>();
+        for (PRPlayerRank playerRank : targetPlayer.getRanks()) {
+            ranknames.add(playerRank.getName());
+        }
+
+        for (String rankname : ranknames) {
             PRRank rank = CacheManager.getRank(rankname);
             if (rank != null) {
                 if (rank.getWeight() > playerHighestRankWeight) {
@@ -293,11 +306,10 @@ public class TablistManager {
             if (playerHighestRank != null) {
                 for (Team team : scoreboard.getTeams()) {
                     if (team.getName().contains("-")) {
-                        if (
-                            team.getName().split("-")[1].equals(playerHighestRank.getName())
-                        ) {
+                        if (team.getName().split("-")[1].equals(playerHighestRank.getName())) {
                             team.addEntry(player.getName());
-                            PowerRanksVerbose.log("TablistSort", "Setting " + player.getName() + " to scoreboard team: " + team.getName());
+                            PowerRanksVerbose.log("TablistSort",
+                                    "Setting " + player.getName() + " to scoreboard team: " + team.getName());
                         } else {
                             team.removeEntry(player.getName());
                         }

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -84,7 +84,9 @@ public class TablistManager {
 
                 int newTotalRankWeight = 0;
                 for (PRRank rank : sortedRanks) {
-                    newTotalRankWeight += rank.getWeight();
+                    if (rank != null) {
+                        newTotalRankWeight += rank.getWeight();
+                    }
                 }
                 if (totalWeight != newTotalRankWeight) {
                     totalWeight = newTotalRankWeight;

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -142,7 +142,10 @@ public class TablistManager {
                     animation.update();
                 }
 
-                for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+                    // ((CraftHumanEntity) player).getHandle();
+                    // PRPlayer prPlayer = CacheManager.getPlayer(player.getUniqueId().toString());
+                    // prPlayer.sendCustompacket(PowerPacket.Type.LIST_HEADER, new PowerPacket());
                     player.setPlayerListHeader(getHeader());
                     player.setPlayerListFooter(getFooter());
                 }

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -221,13 +221,19 @@ public class TablistManager {
     }
 
     public void stop() {
-        // if (!PowerRanks.getTablistConfigManager().getBool("sorting.enabled", false)) {
-        //     return;
-        // }
+        for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+            player.setPlayerListHeader(null);
+            player.setPlayerListFooter(null);
+        }
+
+        headerLines = new ArrayList<String>();
+        footerLines = new ArrayList<String>();
+        tablistAnimations = new HashMap<String, TablistAnimation>();
 
         for (Entry<UUID,Integer> entry : playerHighestWeight.entrySet()) {
             entry.setValue(Integer.MIN_VALUE);
         }
+
         numRanks = -1;
         totalWeight = -1;
 

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -32,6 +32,7 @@ public class TablistManager {
     private ArrayList<String> headerLines = new ArrayList<String>();
     private ArrayList<String> footerLines = new ArrayList<String>();
     private HashMap<String, TablistAnimation> tablistAnimations = new HashMap<String, TablistAnimation>();
+    private int verboseLogInterval = 0;
 
     public TablistManager() {}
 
@@ -146,7 +147,11 @@ public class TablistManager {
                     player.setPlayerListFooter(getFooter());
                 }
 
-                PowerRanksVerbose.log("task", "Running task header/footer tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+                if (verboseLogInterval > 100) {
+                    PowerRanksVerbose.log("task", "Running task header/footer tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+                    verboseLogInterval = 0;
+                }
+                verboseLogInterval++;
             }
         };
         headerFooterTask.runTaskTimer(

--- a/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/TablistManager.java
@@ -2,11 +2,14 @@ package nl.svenar.PowerRanks.Data;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.PowerRanks;
@@ -25,87 +28,200 @@ public class TablistManager {
     private HashMap <UUID, Integer> playerHighestWeight = new HashMap <UUID, Integer>();
     private int numRanks = -1;
     private int totalWeight = -1;
-    private BukkitRunnable runnable;
+    private BukkitRunnable sortingTask, headerFooterTask;
+    private ArrayList<String> headerLines = new ArrayList<String>();
+    private ArrayList<String> footerLines = new ArrayList<String>();
+    private HashMap<String, TablistAnimation> tablistAnimations = new HashMap<String, TablistAnimation>();
 
     public TablistManager() {}
 
     public void start() {
         PowerRanksVerbose.log("TablistSort", "Initializing");
-        if (!PowerRanks.getConfigManager().getBool("tablist_modification.sorting.enabled", true)) {
-            return;
+        if (PowerRanks.getTablistConfigManager().getBool("sorting.enabled", true)) {
+            setupSorting();
         }
-
-        runnable = new BukkitRunnable() {
-                @Override
-                public void run() {
-                    Instant startTime = Instant.now();
-
-                    if (scoreboard == null) {
-                        try {
-                            scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-                            for (Player player: Bukkit.getServer().getOnlinePlayers()) {
-                                onPlayerJoin(player);
-                            }
-                        } catch (Exception e) {}
-                    }
-
-                    if (scoreboard == null) {
-                        return;
-                    }
-
-                    boolean doUpdateRanks = false;
-
-                    List <PRRank> sortedRanks = PRUtil.sortRanksByWeight(
-                        CacheManager.getRanks()
-                    );
-                    if (!PowerRanks.getConfigManager().getBool("tablist_modification.sorting.reverse", false)) {
-                        Collections.reverse(sortedRanks);
-                    }
-
-                    if (numRanks != CacheManager.getRanks().size()) {
-                        numRanks = CacheManager.getRanks().size();
-                        doUpdateRanks = true;
-                    }
-
-                    int newTotalRankWeight = 0;
-                    for (PRRank rank: sortedRanks) {
-                        newTotalRankWeight += rank.getWeight();
-                    }
-                    if (totalWeight != newTotalRankWeight) {
-                        totalWeight = newTotalRankWeight;
-                        doUpdateRanks = true;
-                    }
-
-                    if (doUpdateRanks) {
-                        for (Team team : scoreboard.getTeams()) {
-                            for (String entry: team.getEntries()) {
-                                team.removeEntry(entry);
-                            }
-                            team.unregister();
-                        }
-                        for (int i = 0; i < sortedRanks.size(); i++) {
-                            scoreboard.registerNewTeam(i + "-" + sortedRanks.get(i).getName());
-                            PowerRanksVerbose.log("TablistSort", "Creating new scoreboard team: " + i + "-" + sortedRanks.get(i).getName());
-                        }
-                    }
-
-                    for (Player player: Bukkit.getServer().getOnlinePlayers()) {
-                        updateSorting(player);
-                    }
-
-                    PowerRanksVerbose.log("task", "Running task sort tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
-                }
-            };
-            runnable.runTaskTimer(
-                PowerRanks.getInstance(),
-                0,
-                PowerRanks.getInstance().TASK_TPS * PowerRanks.getConfigManager().getInt("tablist_modification.sorting.update-interval", 5)
-            );
+        if (PowerRanks.getTablistConfigManager().getBool("header-footer.enabled", true)) {
+            setupHeaderFooter();
+        }
             
     }
 
+    private void setupSorting() {
+        sortingTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Instant startTime = Instant.now();
+
+                if (scoreboard == null) {
+                    try {
+                        scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
+                        for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                            onPlayerJoin(player);
+                        }
+                    } catch (Exception e) {}
+                }
+
+                if (scoreboard == null) {
+                    return;
+                }
+
+                boolean doUpdateRanks = false;
+
+                List <PRRank> sortedRanks = PRUtil.sortRanksByWeight(
+                    CacheManager.getRanks()
+                );
+                if (!PowerRanks.getTablistConfigManager().getBool("sorting.reverse", false)) {
+                    Collections.reverse(sortedRanks);
+                }
+
+                if (numRanks != CacheManager.getRanks().size()) {
+                    numRanks = CacheManager.getRanks().size();
+                    doUpdateRanks = true;
+                }
+
+                int newTotalRankWeight = 0;
+                for (PRRank rank: sortedRanks) {
+                    newTotalRankWeight += rank.getWeight();
+                }
+                if (totalWeight != newTotalRankWeight) {
+                    totalWeight = newTotalRankWeight;
+                    doUpdateRanks = true;
+                }
+
+                if (doUpdateRanks) {
+                    for (Team team : scoreboard.getTeams()) {
+                        for (String entry: team.getEntries()) {
+                            team.removeEntry(entry);
+                        }
+                        team.unregister();
+                    }
+                    for (int i = 0; i < sortedRanks.size(); i++) {
+                        scoreboard.registerNewTeam(i + "-" + sortedRanks.get(i).getName());
+                        PowerRanksVerbose.log("TablistSort", "Creating new scoreboard team: " + i + "-" + sortedRanks.get(i).getName());
+                    }
+                }
+
+                for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                    updateSorting(player);
+                }
+
+                PowerRanksVerbose.log("task", "Running task sort tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+            }
+        };
+        sortingTask.runTaskTimer(
+            PowerRanks.getInstance(),
+            0,
+            PowerRanks.getInstance().TASK_TPS * PowerRanks.getTablistConfigManager().getInt("sorting.update-interval", 1)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupHeaderFooter() {
+        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.header", new ArrayList<String>())) {
+            headerLines.add(line);
+        }
+
+        for (String line : (ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.footer", new ArrayList<String>())) {
+            footerLines.add(line);
+        }
+
+        for (String animationName : PowerRanks.getTablistConfigManager().getKeys("header-footer.animations")) {
+            TablistAnimation newAnimation = new TablistAnimation();
+            newAnimation.setDelay(PowerRanks.getTablistConfigManager().getInt("header-footer.animations." + animationName + ".delay", 1));
+            newAnimation.setFrames((ArrayList<String>) PowerRanks.getTablistConfigManager().getList("header-footer.animations." + animationName + ".frames", new ArrayList<String>()));
+            tablistAnimations.put(animationName, newAnimation);
+        }
+
+        headerFooterTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Instant startTime = Instant.now();
+
+                for (TablistAnimation animation : tablistAnimations.values()) {
+                    animation.update();
+                }
+
+                for (Player player: Bukkit.getServer().getOnlinePlayers()) {
+                    player.setPlayerListHeader(getHeader());
+                    player.setPlayerListFooter(getFooter());
+                }
+
+                PowerRanksVerbose.log("task", "Running task header/footer tablist in " + Duration.between(startTime, Instant.now()).toMillis() + "ms");
+            }
+        };
+        headerFooterTask.runTaskTimer(
+            PowerRanks.getInstance(),
+            0,
+            PowerRanks.getTablistConfigManager().getInt("header-footer.update-interval", 1)
+        );
+    }
+
+    private String formatAnimations(String line) {
+        Pattern pattern = Pattern.compile("\\{.+:.+\\}");
+        Matcher matcher = pattern.matcher(line);
+
+        while (matcher.find()) {
+            String symbol = line.substring(matcher.start(), matcher.end());
+            String replacement = "";
+
+            Matcher keyMatcher = Pattern.compile("\\{.+:").matcher(symbol);
+            Matcher valueMatcher = Pattern.compile(":.+\\}").matcher(symbol);
+            keyMatcher.find();
+            valueMatcher.find();
+            String key = symbol.substring(keyMatcher.start(), keyMatcher.end());
+            String value = symbol.substring(valueMatcher.start(), valueMatcher.end());
+            key = key.substring(1, key.length() - 1);
+            value = value.substring(1, value.length() - 1);
+
+            switch (key.toLowerCase()) {
+                case "animation":
+                    TablistAnimation animation = tablistAnimations.get(value);
+                    if (animation != null) {
+                        replacement = animation.getCurrentFrame();
+                    }
+                    break;
+                
+                default:
+                    break;
+            }
+
+            line = line.replace(symbol, replacement);
+            matcher = pattern.matcher(line);
+        }
+
+        return line;
+    }
+
+    private String getHeader() {
+        String output = "";
+
+        for (String line : headerLines) {
+            output += line + "\n";
+        }
+
+        output = output.substring(0, output.length() - 1);
+        output = formatAnimations(output);
+        output = PowerRanks.chatColor(output, true);
+
+        return output;
+    }
+
+    private String getFooter() {
+        String output = "";
+
+        for (String line : footerLines) {
+            output += line + "\n";
+        }
+
+        output = output.substring(0, output.length() - 1);
+        output = formatAnimations(output);
+        output = PowerRanks.chatColor(output, true);
+
+        return output;
+    }
+
     public void stop() {
-        // if (!PowerRanks.getConfigManager().getBool("tablist_modification.sorting.enabled", false)) {
+        // if (!PowerRanks.getTablistConfigManager().getBool("sorting.enabled", false)) {
         //     return;
         // }
 
@@ -117,9 +233,14 @@ public class TablistManager {
 
         PowerRanksVerbose.log("TablistSort", "Stopping");
 
-        if (runnable != null) {
-            runnable.cancel();
-            runnable = null;
+        if (sortingTask != null) {
+            sortingTask.cancel();
+            sortingTask = null;
+        }
+
+        if (headerFooterTask != null) {
+            headerFooterTask.cancel();
+            headerFooterTask = null;
         }
 
         if (scoreboard != null) {

--- a/src/main/java/nl/svenar/PowerRanks/Data/Users.java
+++ b/src/main/java/nl/svenar/PowerRanks/Data/Users.java
@@ -18,6 +18,7 @@ import nl.svenar.PowerRanks.Cache.CacheManager;
 // import nl.svenar.PowerRanks.Cache.CachedConfig;
 import nl.svenar.common.structure.PRPermission;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -33,7 +34,10 @@ public class Users implements Listener {
 			return "";
 		}
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 		List<PRRank> playerRanks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
 			PRRank rank = CacheManager.getRank(rankname);
@@ -288,7 +292,10 @@ public class Users implements Listener {
 		}
 
 		for (PRPlayer prPlayer : CacheManager.getPlayers()) {
-			List<String> ranknames = prPlayer.getRanks();
+			List<String> ranknames = new ArrayList<>();
+			for (PRPlayerRank playerRank : prPlayer.getRanks()) {
+				ranknames.add(playerRank.getName());
+			}
 
 			List<PRRank> ranks = new ArrayList<PRRank>();
 			for (String rankname : ranknames) {
@@ -300,7 +307,16 @@ public class Users implements Listener {
 
 			for (PRRank rank : ranks) {
 				if (rank == CacheManager.getRank(rankToDelete)) {
-					prPlayer.removeRank(rank.getName());
+					PRPlayerRank playerRank = null;
+					for (PRPlayerRank targetPlayerRank : prPlayer.getRanks()) {
+						if (targetPlayerRank.getName().equals(rank.getName())) {
+							playerRank = targetPlayerRank;
+							break;
+						}
+					}
+					if (playerRank != null) {
+						prPlayer.removeRank(playerRank);
+					}
 				}
 			}
 			// if (CacheManager.getRank(CacheManager.getDefaultRank()) ==
@@ -455,7 +471,10 @@ public class Users implements Listener {
 	public String getPrefix(Player player) {
 		String prefix = "";
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
@@ -491,7 +510,10 @@ public class Users implements Listener {
 	public String getSuffix(Player player) {
 		String suffix = "";
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
@@ -528,7 +550,10 @@ public class Users implements Listener {
 		String color = "";
 		// String rankname = getGroup(player);
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
@@ -547,7 +572,10 @@ public class Users implements Listener {
 
 	public String getNameColor(Player player) {
 		String color = "";
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
@@ -957,7 +985,7 @@ public class Users implements Listener {
 		return true;
 	}
 
-    @SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked")
 	public boolean addUserTag(Player player, String tag) {
 		Map<String, String> availableUsertags = (Map<String, String>) PowerRanks.getUsertagManager().getMap("usertags",
 				new HashMap<String, String>());
@@ -983,7 +1011,7 @@ public class Users implements Listener {
 		return true;
 	}
 
-    @SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked")
 	public boolean delUserTag(Player player, String tag) {
 		Map<String, String> availableUsertags = (Map<String, String>) PowerRanks.getUsertagManager().getMap("usertags",
 				new HashMap<String, String>());
@@ -1014,12 +1042,12 @@ public class Users implements Listener {
 		return setUserTag(player, tag);
 	}
 
-    public boolean addUserTag(String playername, String tag) {
+	public boolean addUserTag(String playername, String tag) {
 		Player player = Bukkit.getServer().getPlayer(playername);
 		return addUserTag(player, tag);
 	}
 
-    public boolean delUserTag(String playername, String tag) {
+	public boolean delUserTag(String playername, String tag) {
 		Player player = Bukkit.getServer().getPlayer(playername);
 		return delUserTag(player, tag);
 	}

--- a/src/main/java/nl/svenar/PowerRanks/Events/OnChat.java
+++ b/src/main/java/nl/svenar/PowerRanks/Events/OnChat.java
@@ -24,6 +24,7 @@ import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.PowerRanks.addons.PowerRanksAddon;
 import nl.svenar.PowerRanks.addons.PowerRanksPlayer;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -48,7 +49,10 @@ public class OnChat implements Listener {
 
 				String format = PowerRanks.getConfigManager().getString("chat.format", "");
 
-				List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+				List<String> ranknames = new ArrayList<>();
+				for (PRPlayerRank rank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+					ranknames.add(rank.getName());
+				}
 
 				List<PRRank> ranks = new ArrayList<PRRank>();
 				for (String rankname : ranknames) {
@@ -117,7 +121,8 @@ public class OnChat implements Listener {
 						+ PowerRanks.applyMultiColorFlow(chatColor, playersChatMessage);
 
 				// Dirty PremiumVanish work around
-				if (Objects.nonNull(PowerRanks.getInstance().getServer().getPluginManager().getPlugin("PremiumVanish"))) {
+				if (Objects
+						.nonNull(PowerRanks.getInstance().getServer().getPluginManager().getPlugin("PremiumVanish"))) {
 					if (player_formatted_chat_msg.endsWith("/")) {
 						player_formatted_chat_msg = player_formatted_chat_msg.substring(0,
 								player_formatted_chat_msg.length() - 1);
@@ -136,7 +141,8 @@ public class OnChat implements Listener {
 										!PowerRanks.plugin_hook_deluxetags ? usertag
 												: PowerRanks.getInstance().getDeluxeTagsHook()
 														.getPlayerDisplayTag(player))
-								.put("player", player_formatted_name).put("msg", PowerRanks.chatColor(player_formatted_chat_msg, true))
+								.put("player", player_formatted_name)
+								.put("msg", PowerRanks.chatColor(player_formatted_chat_msg, true))
 								.put("format", e.getFormat()).put("world", player.getWorld().getName()).build(),
 						'[', ']');
 

--- a/src/main/java/nl/svenar/PowerRanks/Events/OnInteract.java
+++ b/src/main/java/nl/svenar/PowerRanks/Events/OnInteract.java
@@ -1,5 +1,6 @@
 package nl.svenar.PowerRanks.Events;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
@@ -19,6 +20,7 @@ import nl.svenar.PowerRanks.External.VaultHook;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.PowerRanks.gui.GUI;
 import nl.svenar.PowerRanks.gui.GUIPage.GUI_PAGE_ID;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class OnInteract implements Listener {
@@ -74,7 +76,8 @@ public class OnInteract implements Listener {
 				if (player.hasPermission("powerranks.signs.setrank")) {
 					PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(sign_argument));
 					if (rank != null) {
-						CacheManager.getPlayer(player.getUniqueId().toString()).setRank(rank.getName());
+						PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+						CacheManager.getPlayer(player.getUniqueId().toString()).setRank(playerRank);
 						player.sendMessage(Util.powerFormatter(
 								PowerRanks.getLanguageManager().getFormattedMessage(
 										"commands.setrank.success-receiver"),
@@ -92,7 +95,8 @@ public class OnInteract implements Listener {
 				if (player.hasPermission("powerranks.signs.setrank")) {
 					PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(sign_argument));
 					if (rank != null) {
-						CacheManager.getPlayer(player.getUniqueId().toString()).addRank(rank.getName());
+						PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+						CacheManager.getPlayer(player.getUniqueId().toString()).addRank(playerRank);
 
 						// Messages.messageSetRankSuccessSender(player, t, rank);
 						player.sendMessage(Util.powerFormatter(
@@ -111,8 +115,10 @@ public class OnInteract implements Listener {
 			} else if (sign_command.equalsIgnoreCase("checkrank")) {
 				if (player.hasPermission("powerranks.signs.checkrank")) {
 
-					List<String> playerRanks = CacheManager.getPlayer(((Player) player).getUniqueId().toString())
-							.getRanks();
+					List<String> playerRanks = new ArrayList<>();
+					for (PRPlayerRank rank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+						playerRanks.add(rank.getName());
+					}
 					if (playerRanks.size() > 0) {
 						player.sendMessage(Util.powerFormatter(
 								PowerRanks.getLanguageManager()
@@ -195,8 +201,8 @@ public class OnInteract implements Listener {
 									PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(sign_argument));
 									if (rank != null) {
 										if (rank != null) {
-											CacheManager.getPlayer(player.getUniqueId().toString())
-													.addRank(rank.getName());
+											PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+											CacheManager.getPlayer(player.getUniqueId().toString()).addRank(playerRank);
 
 											player.sendMessage(Util.powerFormatter(
 													PowerRanks.getLanguageManager().getFormattedMessage(

--- a/src/main/java/nl/svenar/PowerRanks/Events/OnJoin.java
+++ b/src/main/java/nl/svenar/PowerRanks/Events/OnJoin.java
@@ -12,6 +12,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
+import nl.svenar.PowerRanks.Data.PowerRanksVerbose;
 import nl.svenar.PowerRanks.addons.PowerRanksAddon;
 import nl.svenar.PowerRanks.addons.PowerRanksPlayer;
 
@@ -87,7 +88,10 @@ public class OnJoin implements Listener {
 	}
 
 	private static void validatePlayerData(Player player) {
-		if (CacheManager.getPlayer(player.getUniqueId().toString()) == null) {
+        boolean exists = CacheManager.getPlayer(player.getUniqueId().toString()) != null;
+        PowerRanksVerbose.log("onJoin", "Player " + player.getName() + " (" + player.getUniqueId().toString() + " " + (exists ? "exists" : "does not exist"));
+        
+		if (!exists) {
 			CacheManager.createPlayer(player);
 		}
 	}

--- a/src/main/java/nl/svenar/PowerRanks/External/PowerRanksExpansion.java
+++ b/src/main/java/nl/svenar/PowerRanks/External/PowerRanksExpansion.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Data.Users;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
@@ -261,12 +262,14 @@ public class PowerRanksExpansion extends PlaceholderExpansion {
 
 	private List<PRRank> getPlayerRanksSorted(Player player) {
 		List<PRRank> playerRanks = new ArrayList<PRRank>();
-		for (String rankname : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
-			PRRank rank = CacheManager.getRank(rankname);
+
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				playerRanks.add(rank);
 			}
 		}
+
 		return PRUtil.reverseRanks(PRUtil.sortRanksByWeight(playerRanks));
 	}
 }

--- a/src/main/java/nl/svenar/PowerRanks/External/PowerRanksVaultChat.java
+++ b/src/main/java/nl/svenar/PowerRanks/External/PowerRanksVaultChat.java
@@ -4,6 +4,7 @@ import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.api.PowerRanksAPI;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -96,10 +97,10 @@ public class PowerRanksVaultChat extends Chat {
 
 	@Override
 	public String getPlayerPrefix(String worldName, String playerName) {
-		List<String> ranknames = CacheManager.getPlayer(playerName).getRanks();
 		List<PRRank> ranks = new ArrayList<PRRank>();
-		for (String rankname : ranknames) {
-			PRRank rank = CacheManager.getRank(rankname);
+
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(playerName).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				ranks.add(rank);
 			}
@@ -116,10 +117,10 @@ public class PowerRanksVaultChat extends Chat {
 
 	@Override
 	public String getPlayerSuffix(String worldName, String playerName) {
-		List<String> ranknames = CacheManager.getPlayer(playerName).getRanks();
 		List<PRRank> ranks = new ArrayList<PRRank>();
-		for (String rankname : ranknames) {
-			PRRank rank = CacheManager.getRank(rankname);
+
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(playerName).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				ranks.add(rank);
 			}
@@ -193,10 +194,10 @@ public class PowerRanksVaultChat extends Chat {
 
 	@Override
 	public void setPlayerPrefix(String worldName, String playerName, String value) {
-		List<String> ranknames = CacheManager.getPlayer(playerName).getRanks();
 		List<PRRank> ranks = new ArrayList<PRRank>();
-		for (String rankname : ranknames) {
-			PRRank rank = CacheManager.getRank(rankname);
+
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(playerName).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				ranks.add(rank);
 			}
@@ -212,10 +213,10 @@ public class PowerRanksVaultChat extends Chat {
 
 	@Override
 	public void setPlayerSuffix(String worldName, String playerName, String value) {
-		List<String> ranknames = CacheManager.getPlayer(playerName).getRanks();
 		List<PRRank> ranks = new ArrayList<PRRank>();
-		for (String rankname : ranknames) {
-			PRRank rank = CacheManager.getRank(rankname);
+
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(playerName).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				ranks.add(rank);
 			}

--- a/src/main/java/nl/svenar/PowerRanks/External/PowerRanksVaultPermission.java
+++ b/src/main/java/nl/svenar/PowerRanks/External/PowerRanksVaultPermission.java
@@ -12,6 +12,7 @@ import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Data.PowerRanksVerbose;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.api.PowerRanksAPI;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -220,7 +221,10 @@ public class PowerRanksVaultPermission extends Permission {
 		ArrayList<String> groups = new ArrayList<String>();
 		// groups.add(CachedPlayers.getString("players." + player.getUniqueId() +
 		// ".rank"));
-		List<String> ranks = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranks = new ArrayList<>();
+		for (PRPlayerRank rank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranks.add(rank.getName());
+		}
 		if (ranks != null) {
 			for (String rank : ranks) {
 				groups.add(rank);
@@ -239,10 +243,9 @@ public class PowerRanksVaultPermission extends Permission {
 	@Override
 	public String getPrimaryGroup(String world, OfflinePlayer player) {
 		PowerRanksVerbose.log("PowerRanksVaultPermission.getPrimaryGroup(...)", "Called, player: " + player.getName());
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
 		List<PRRank> ranks = new ArrayList<PRRank>();
-		for (String rankname : ranknames) {
-			PRRank rank = CacheManager.getRank(rankname);
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			PRRank rank = CacheManager.getRank(playerRank.getName());
 			if (rank != null) {
 				ranks.add(rank);
 			}

--- a/src/main/java/nl/svenar/PowerRanks/External/TABHook.java
+++ b/src/main/java/nl/svenar/PowerRanks/External/TABHook.java
@@ -10,6 +10,7 @@ import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Util.PluginReloader;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -99,7 +100,8 @@ public class TABHook {
                 newSortingTypes.add(type);
             } else {
 
-                // PowerRanks.getInstance().getLogger().warning(type.split(":")[1] + " - " + String.join(",", sortingList));
+                // PowerRanks.getInstance().getLogger().warning(type.split(":")[1] + " - " +
+                // String.join(",", sortingList));
 
                 if (String.join(",", sortingList).length() != type.split(":")[1].length()) {
                     // doRestart = true; // Restart the plugin
@@ -130,9 +132,9 @@ public class TABHook {
 
     static List<PRRank> getSortedRanks(PRPlayer prPlayer) {
         List<PRRank> playerRanks = new ArrayList<PRRank>();
-        for (String rankname : prPlayer.getRanks()) {
-            if (CacheManager.getRank(rankname) != null) {
-                playerRanks.add(CacheManager.getRank(rankname));
+        for (PRPlayerRank rank : prPlayer.getRanks()) {
+            if (CacheManager.getRank(rank.getName()) != null) {
+                playerRanks.add(CacheManager.getRank(rank.getName()));
             }
         }
 

--- a/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
+++ b/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
@@ -45,6 +45,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Cache.LanguageManager;
 import nl.svenar.PowerRanks.Commands.PowerCommandHandler;
+import nl.svenar.PowerRanks.Data.BungeecordManager;
 import nl.svenar.PowerRanks.Data.Messages;
 import nl.svenar.PowerRanks.Data.PowerPermissibleBase;
 import nl.svenar.PowerRanks.Data.PowerRanksVerbose;
@@ -109,6 +110,8 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	private static LanguageManager languageManager;
 	private static PowerConfigManager usertagManager;
 	private static PowerConfigManager tablistConfigManager;
+
+    private BungeecordManager bungeecordManager;
 
 	// Soft Dependencies
 	private VaultHook vaultHook;
@@ -202,6 +205,9 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 		GUI.setPlugin(this);
 
+        this.bungeecordManager = new BungeecordManager(this);
+        this.bungeecordManager.start();
+
 		this.tablistManager = new TablistManager();
 		this.tablistManager.start();
 
@@ -241,6 +247,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 	public void onDisable() {
 		this.tablistManager.stop();
+        this.bungeecordManager.stop();
 
 		Bukkit.getServer().getScheduler().cancelTasks(this);
 
@@ -1063,6 +1070,10 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	public static PowerConfigManager getTablistConfigManager() {
 		return tablistConfigManager;
 	}
+
+    public BungeecordManager getBungeecordManager() {
+        return this.bungeecordManager;
+    }
 
     public static PowerColor getPowerColor() {
         return powerColor;

--- a/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
+++ b/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
@@ -80,6 +80,7 @@ import nl.svenar.common.storage.PowerConfigManager;
 import nl.svenar.common.storage.provided.YAMLConfigManager;
 import nl.svenar.common.structure.PRPermission;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 import nl.svenar.common.utils.PRUtil;
 
@@ -99,7 +100,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	public static PluginDescriptionFile pdf;
 	public AddonsManager addonsManager;
 	private TablistManager tablistManager;
-    private static PowerColor powerColor;
+	private static PowerColor powerColor;
 	public String plp;
 	public static Logger log;
 	public static String fileLoc;
@@ -112,7 +113,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	private static PowerConfigManager usertagManager;
 	private static PowerConfigManager tablistConfigManager;
 
-    private BungeecordManager bungeecordManager;
+	private BungeecordManager bungeecordManager;
 
 	// Soft Dependencies
 	private VaultHook vaultHook;
@@ -172,7 +173,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 		PowerRanks.log.info("");
 		PowerRanks.log.info("=== ------- LOADING CONFIGURATION ------ ===");
-        PowerRanks.powerColor = new PowerColor();
+		PowerRanks.powerColor = new PowerColor();
 		new Messages(this);
 		new PowerRanksVerbose(this);
 
@@ -209,8 +210,8 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 		GUI.setPlugin(this);
 
-        this.bungeecordManager = new BungeecordManager(this);
-        this.bungeecordManager.start();
+		this.bungeecordManager = new BungeecordManager(this);
+		this.bungeecordManager.start();
 
 		this.tablistManager = new TablistManager();
 		this.tablistManager.start();
@@ -251,7 +252,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 	public void onDisable() {
 		this.tablistManager.stop();
-        this.bungeecordManager.stop();
+		this.bungeecordManager.stop();
 
 		Bukkit.getServer().getScheduler().cancelTasks(this);
 
@@ -804,8 +805,10 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 					prefix_format += nameColor;
 
-					prefix_format = getPowerColor().format(PowerColor.UNFORMATTED_COLOR_CHAR, prefix_format, true, true);
-					suffix_format = getPowerColor().format(PowerColor.UNFORMATTED_COLOR_CHAR, suffix_format, true, true);
+					prefix_format = getPowerColor().format(PowerColor.UNFORMATTED_COLOR_CHAR, prefix_format, true,
+							true);
+					suffix_format = getPowerColor().format(PowerColor.UNFORMATTED_COLOR_CHAR, suffix_format, true,
+							true);
 
 					INametagApi nteAPI = NametagEdit.getApi();
 					if (nteAPI != null) {
@@ -824,7 +827,10 @@ public class PowerRanks extends JavaPlugin implements Listener {
 		} catch (NoSuchMethodError e) {
 		}
 
-		List<String> ranknames = CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
 
 		List<PRRank> ranks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
@@ -934,7 +940,8 @@ public class PowerRanks extends JavaPlugin implements Listener {
 			format = PowerRanks.chatColor(format, true);
 
 			player.setPlayerListName(format);
-            PowerRanksVerbose.log("updateTablistName", "Updated " + player.getName() + "'s tablist format to: " + player.getPlayerListName());
+			PowerRanksVerbose.log("updateTablistName",
+					"Updated " + player.getName() + "'s tablist format to: " + player.getPlayerListName());
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -1035,7 +1042,11 @@ public class PowerRanks extends JavaPlugin implements Listener {
 			permissions.add(permission);
 		}
 
-		List<String> ranknames = prPlayer.getRanks();
+		List<String> ranknames = new ArrayList<>();
+		for (PRPlayerRank playerRank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranknames.add(playerRank.getName());
+		}
+
 		List<PRRank> playerRanks = new ArrayList<PRRank>();
 		for (String rankname : ranknames) {
 			PRRank rank = CacheManager.getRank(rankname);
@@ -1092,9 +1103,9 @@ public class PowerRanks extends JavaPlugin implements Listener {
 		return permissions;
 	}
 
-    public TablistManager getTablistManager() {
-        return this.tablistManager;
-    }
+	public TablistManager getTablistManager() {
+		return this.tablistManager;
+	}
 
 	public static PowerConfigManager getConfigManager() {
 		return configManager;
@@ -1107,17 +1118,18 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	public static PowerConfigManager getUsertagManager() {
 		return usertagManager;
 	}
+
 	public static PowerConfigManager getTablistConfigManager() {
 		return tablistConfigManager;
 	}
 
-    public BungeecordManager getBungeecordManager() {
-        return this.bungeecordManager;
-    }
+	public BungeecordManager getBungeecordManager() {
+		return this.bungeecordManager;
+	}
 
-    public static PowerColor getPowerColor() {
-        return powerColor;
-    }
+	public static PowerColor getPowerColor() {
+		return powerColor;
+	}
 
 	public static PowerRanks getInstance() {
 		return instance;

--- a/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
+++ b/src/main/java/nl/svenar/PowerRanks/PowerRanks.java
@@ -108,6 +108,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 	private static PowerConfigManager configManager;
 	private static LanguageManager languageManager;
 	private static PowerConfigManager usertagManager;
+	private static PowerConfigManager tablistConfigManager;
 
 	// Soft Dependencies
 	private VaultHook vaultHook;
@@ -177,6 +178,8 @@ public class PowerRanks extends JavaPlugin implements Listener {
 		languageManager.setLanguage(configManager.getString("general.language", "en"));
 		PowerRanks.log.info("Loading usertags file");
 		usertagManager = new YAMLConfigManager(PowerRanks.fileLoc, "usertags.yml");
+		PowerRanks.log.info("Loading tablist file");
+		tablistConfigManager = new YAMLConfigManager(PowerRanks.fileLoc, "tablist.yml", "tablist.yml");
 
 		PowerRanks.log.info("");
 		PowerRanks.log.info("=== ---------- LOADING ADDONS ---------- ===");
@@ -287,6 +290,13 @@ public class PowerRanks extends JavaPlugin implements Listener {
 			getUsertagManager().save();
 		} else {
 			getLogger().warning("Failed to save usertags file!");
+			hasErrorInSaving = true;
+		}
+
+		if (Objects.nonNull(getTablistConfigManager())) {
+			getTablistConfigManager().save();
+		} else {
+			getLogger().warning("Failed to save tablist config file!");
 			hasErrorInSaving = true;
 		}
 
@@ -1049,6 +1059,9 @@ public class PowerRanks extends JavaPlugin implements Listener {
 
 	public static PowerConfigManager getUsertagManager() {
 		return usertagManager;
+	}
+	public static PowerConfigManager getTablistConfigManager() {
+		return tablistConfigManager;
 	}
 
     public static PowerColor getPowerColor() {

--- a/src/main/java/nl/svenar/PowerRanks/api/PowerRanksAPI.java
+++ b/src/main/java/nl/svenar/PowerRanks/api/PowerRanksAPI.java
@@ -13,7 +13,7 @@ import nl.svenar.common.structure.PRRank;
 
 public class PowerRanksAPI {
 
-	private String API_VERSION = "1.2";
+	private String API_VERSION = "1.3";
 
 	public static PowerRanks plugin;
 	private Users users;
@@ -459,6 +459,71 @@ public class PowerRanksAPI {
 	public boolean removePermission(Player player, String permission) {
 		return users.delPlayerPermission(player.getName(), permission);
 	}
+
+    /**
+     * Create a usertag on the server
+     * 
+     * @param usertag
+     * @param value
+     * @return true if successful, false otherwise
+     */
+    public boolean createUsertag(String usertag, String value) {
+        return this.createUsertag(usertag, value);
+    }
+
+    /**
+     * Change a usertag on the server
+     * 
+     * @param usertag
+     * @param value
+     * @return true if successful, false otherwise
+     */
+    public boolean editUsertag(String usertag, String value) {
+        return this.editUsertag(usertag, value);
+    }
+
+    /**
+     * Delete a usertag from the server
+     * 
+     * @param usertag
+     * @return true if successful, false otherwise
+     */
+    public boolean removeUsertag(String usertag) {
+        return this.users.removeUserTag(usertag);
+    }
+
+    /**
+     * Assign a usertag to an player
+     * 
+     * @param player
+     * @param usertag
+     * @return true if successful, false otherwise
+     */
+    public boolean setUsertag(Player player, String usertag) {
+        return this.users.setUserTag(player.getName(), usertag);
+    }
+
+    /**
+     * Add a usertag to an player
+     * 
+     * @param player
+     * @param usertag
+     * @return true if successful, false otherwise
+     */
+    public boolean addUsertag(Player player, String usertag) {
+        return this.users.addUserTag(player.getName(), usertag);
+    }
+
+    /**
+     * Remove an usertag from a player
+     * 
+     * @param player
+     * @param usertag
+     * @return true if successful, false otherwise
+     */
+    public boolean delUsertag(Player player, String usertag) {
+        return this.users.delUserTag(player.getName(), usertag);
+    }
 
 	/**
 	 * Deprecated | replaced by {@link #getPrimaryRank(Player)}

--- a/src/main/java/nl/svenar/PowerRanks/api/PowerRanksAPI.java
+++ b/src/main/java/nl/svenar/PowerRanks/api/PowerRanksAPI.java
@@ -9,6 +9,8 @@ import nl.svenar.PowerRanks.PowerRanks;
 import nl.svenar.PowerRanks.Cache.CacheManager;
 import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.common.structure.PRPermission;
+import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class PowerRanksAPI {
@@ -74,7 +76,11 @@ public class PowerRanksAPI {
 	}
 
 	public List<String> getRanks(Player player) {
-		return CacheManager.getPlayer(player.getUniqueId().toString()).getRanks();
+		List<String> ranks = new ArrayList<>();
+		for (PRPlayerRank rank : CacheManager.getPlayer(player.getUniqueId().toString()).getRanks()) {
+			ranks.add(rank.getName());
+		}
+		return ranks;
 	}
 
 	/**
@@ -87,7 +93,8 @@ public class PowerRanksAPI {
 	public boolean setPlayerRank(Player player, String rankname) {
 		PRRank rank = CacheManager.getRank(rankname);
 		if (rank != null) {
-			CacheManager.getPlayer(player.getUniqueId().toString()).setRank(rank.getName());
+			PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+			CacheManager.getPlayer(player.getUniqueId().toString()).setRank(playerRank);
 		}
 		return rank != null;
 	}
@@ -102,7 +109,8 @@ public class PowerRanksAPI {
 	public boolean addPlayerRank(Player player, String rankname) {
 		PRRank rank = CacheManager.getRank(rankname);
 		if (rank != null) {
-			CacheManager.getPlayer(player.getUniqueId().toString()).addRank(rank.getName());
+			PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+			CacheManager.getPlayer(player.getUniqueId().toString()).addRank(playerRank);
 		}
 		return rank != null;
 	}
@@ -117,7 +125,18 @@ public class PowerRanksAPI {
 	public boolean removePlayerRank(Player player, String rankname) {
 		PRRank rank = CacheManager.getRank(rankname);
 		if (rank != null) {
-			CacheManager.getPlayer(player.getUniqueId().toString()).removeRank(rank.getName());
+			PRPlayer targetPlayer = CacheManager.getPlayer(player.getUniqueId().toString());
+			PRPlayerRank playerRank = null;
+			for (PRPlayerRank targetPlayerRank : targetPlayer.getRanks()) {
+				if (targetPlayerRank.getName().equals(rank.getName())) {
+					playerRank = targetPlayerRank;
+					break;
+				}
+			}
+			if (playerRank != null) {
+				targetPlayer.removeRank(playerRank);
+			}
+			return playerRank != null;
 		}
 		return rank != null;
 	}

--- a/src/main/java/nl/svenar/PowerRanks/gui/GUI.java
+++ b/src/main/java/nl/svenar/PowerRanks/gui/GUI.java
@@ -14,6 +14,7 @@ import nl.svenar.PowerRanks.Data.Users;
 import nl.svenar.PowerRanks.External.VaultHook;
 import nl.svenar.PowerRanks.Util.Util;
 import nl.svenar.PowerRanks.gui.GUIPage.GUI_PAGE_ID;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class GUI {
@@ -88,7 +89,8 @@ public class GUI {
 
 						PRRank rank = CacheManager.getRank(users.getRankIgnoreCase(rankname));
 						if (rank != null) {
-							CacheManager.getPlayer(player.getUniqueId().toString()).setRank(rank.getName());
+							PRPlayerRank playerRank = new PRPlayerRank(rank.getName());
+							CacheManager.getPlayer(player.getUniqueId().toString()).setRank(playerRank);
 							player.sendMessage(Util.powerFormatter(
 									PowerRanks.getLanguageManager().getFormattedMessage(
 											"commands.setrank.success-receiver"),

--- a/src/main/java/nl/svenar/PowerRanks/update/ConfigFilesUpdater.java
+++ b/src/main/java/nl/svenar/PowerRanks/update/ConfigFilesUpdater.java
@@ -21,6 +21,7 @@ import nl.svenar.common.storage.provided.YAMLConfigManager;
 import nl.svenar.common.storage.provided.YAMLStorageManager;
 import nl.svenar.common.structure.PRPermission;
 import nl.svenar.common.structure.PRPlayer;
+import nl.svenar.common.structure.PRPlayerRank;
 import nl.svenar.common.structure.PRRank;
 
 public class ConfigFilesUpdater {
@@ -194,7 +195,7 @@ public class ConfigFilesUpdater {
 
 				newPlayer.setUUID(UUID.fromString(playerUUID));
 				newPlayer.setName(playersYaml.getString("players." + playerUUID + ".name"));
-				newPlayer.setRank(playersYaml.getString("players." + playerUUID + ".rank"));
+				newPlayer.setRank(new PRPlayerRank(playersYaml.getString("players." + playerUUID + ".rank")));
 				newPlayer.setPlaytime(playersYaml.getInt("players." + playerUUID + ".playtime"));
 				if (playersYaml.getString("players." + playerUUID + ".usertag").length() > 0) {
 					newPlayer.addUsertag(playersYaml.getString("players." + playerUUID + ".usertag"));
@@ -209,7 +210,7 @@ public class ConfigFilesUpdater {
 
 				if (!playersYaml.isString("players." + playerUUID + ".subranks")) {
 					for (String playerSubrankName : playersYaml.getConfigurationSection("players." + playerUUID + ".subranks").getKeys(false)) {
-						newPlayer.addRank(playerSubrankName);
+						newPlayer.addRank(new PRPlayerRank(playerSubrankName));
 				// 		PRSubrank newSubrank = new PRSubrank();
 
 				// 		newSubrank.setName(playerSubrankName);

--- a/src/main/java/nl/svenar/common/http/DatabinClient.java
+++ b/src/main/java/nl/svenar/common/http/DatabinClient.java
@@ -2,11 +2,13 @@ package nl.svenar.common.http;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 
+import nl.svenar.common.PowerLogger;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -81,7 +83,19 @@ public class DatabinClient extends PowerHTTPClient {
         String response = this.rawResponse;
         this.rawResponse = "";
 
-        return parseJSON(response);
+        try {
+            return parseJSON(response);
+        } catch (IllegalStateException ise) {
+            PowerLogger.severe("");
+            PowerLogger.severe("An error occurred while parsing response code");
+            PowerLogger.severe("=== ------------------------------------- ===");
+            PowerLogger.severe(response);
+            PowerLogger.severe("=== ------------------------------------- ===");
+            ise.printStackTrace();
+            PowerLogger.severe("");
+
+            return new HashMap<String, String>();
+        }
     }
 
     public String getRawResponse() {

--- a/src/main/java/nl/svenar/common/storage/PowerConfigManager.java
+++ b/src/main/java/nl/svenar/common/storage/PowerConfigManager.java
@@ -190,8 +190,6 @@ public abstract class PowerConfigManager {
      */
     @SuppressWarnings("unchecked")
     public void setKV(String key, Object value) {
-        System.out.println("key: " + key);
-        System.out.println("value: " + value);
         String[] keySplit = key.split("\\.");
         int entries = keySplit.length;
         Object currentKey = this.data;

--- a/src/main/java/nl/svenar/common/storage/PowerSQLConfiguration.java
+++ b/src/main/java/nl/svenar/common/storage/PowerSQLConfiguration.java
@@ -38,6 +38,7 @@ public class PowerSQLConfiguration {
     private boolean useSSL;
     private String tableRanks;
     private String tablePlayers;
+    private String tableMessages;
 
     /**
      * Constructor to initialize SQL connection data
@@ -50,10 +51,11 @@ public class PowerSQLConfiguration {
      * @param useSSL
      * @param tableRanks
      * @param tablePlayers
+     * @param tableMessages
      */
     public PowerSQLConfiguration(String host, int port, String database, String username, String password,
             boolean useSSL,
-            String tableRanks, String tablePlayers) {
+            String tableRanks, String tablePlayers, String tableMessages) {
         this.host = host;
         this.port = port;
         this.database = database;
@@ -62,6 +64,7 @@ public class PowerSQLConfiguration {
         this.useSSL = useSSL;
         this.tableRanks = tableRanks;
         this.tablePlayers = tablePlayers;
+        this.tableMessages = tableMessages;
     }
 
     /**
@@ -128,5 +131,14 @@ public class PowerSQLConfiguration {
      */
     public String getTablePlayers() {
         return this.tablePlayers;
+    }
+
+    /**
+     * Get the name used to store all message data in
+     * 
+     * @return Table name for messages
+     */
+    public String getTableMessages() {
+        return this.tableMessages;
     }
 }

--- a/src/main/java/nl/svenar/common/storage/provided/JSONStorageManager.java
+++ b/src/main/java/nl/svenar/common/storage/provided/JSONStorageManager.java
@@ -209,15 +209,7 @@ public class JSONStorageManager extends PowerStorageManager {
         }
     }
 
-    public String getRanksAsJSON(boolean pretty) {
-        Gson gson = null;
-
-        if (pretty) {
-            gson = new GsonBuilder().setPrettyPrinting().create();
-        } else {
-            gson = new Gson();
-        }
-
+    public Map<String, Object> getRanksAsMap() {
         Map<String, Object> ranks2 = new HashMap<String, Object>();
 
         for (PRRank r : this.getRanks()) {
@@ -231,10 +223,10 @@ public class JSONStorageManager extends PowerStorageManager {
             ranks2.put(r.getName(), serializedRank);
         }
 
-        return gson.toJson(ranks2);
+        return ranks2;
     }
 
-    public String getPlayersAsJSON(boolean pretty) {
+    public String getRanksAsJSON(boolean pretty) {
         Gson gson = null;
 
         if (pretty) {
@@ -243,6 +235,12 @@ public class JSONStorageManager extends PowerStorageManager {
             gson = new Gson();
         }
 
+        Map<String, Object> ranks2 = getRanksAsMap();
+
+        return gson.toJson(ranks2);
+    }
+
+    public Map<String, Object> getPlayersAsMap() {
         Map<String, Object> players2 = new HashMap<String, Object>();
 
         for (PRPlayer p : this.getPlayers()) {
@@ -255,6 +253,20 @@ public class JSONStorageManager extends PowerStorageManager {
             }
             players2.put(p.getUUID().toString(), serializedPlayer);
         }
+
+        return players2;
+    }
+
+    public String getPlayersAsJSON(boolean pretty) {
+        Gson gson = null;
+
+        if (pretty) {
+            gson = new GsonBuilder().setPrettyPrinting().create();
+        } else {
+            gson = new Gson();
+        }
+
+        Map<String, Object> players2 = getPlayersAsMap();
 
         return gson.toJson(players2);
     }

--- a/src/main/java/nl/svenar/common/storage/provided/YAMLConfigManager.java
+++ b/src/main/java/nl/svenar/common/storage/provided/YAMLConfigManager.java
@@ -50,8 +50,8 @@ public class YAMLConfigManager extends PowerConfigManager {
 
     private final DumperOptions yamlOptions = new DumperOptions();
     private final LoaderOptions loaderOptions = new LoaderOptions();
-    private final Representer yamlRepresenter = new Representer();
-    private final Yaml yaml = new Yaml(new Constructor(), yamlRepresenter, yamlOptions, loaderOptions);
+    private final Representer yamlRepresenter = new Representer(yamlOptions);
+    private final Yaml yaml = new Yaml(new Constructor(loaderOptions), yamlRepresenter, yamlOptions, loaderOptions);
 
     private File configFile;
 

--- a/src/main/java/nl/svenar/common/storage/provided/YAMLStorageManager.java
+++ b/src/main/java/nl/svenar/common/storage/provided/YAMLStorageManager.java
@@ -56,8 +56,8 @@ public class YAMLStorageManager extends PowerStorageManager {
 
     private final DumperOptions yamlOptions = new DumperOptions();
     private final LoaderOptions loaderOptions = new LoaderOptions();
-    private final Representer yamlRepresenter = new Representer();
-    private final Yaml yaml = new Yaml(new Constructor(), yamlRepresenter, yamlOptions, loaderOptions);
+    private final Representer yamlRepresenter = new Representer(yamlOptions);
+    private final Yaml yaml = new Yaml(new Constructor(loaderOptions), yamlRepresenter, yamlOptions, loaderOptions);
 
     private File ranksFile, playersFile;
 

--- a/src/main/java/nl/svenar/common/structure/PRPermission.java
+++ b/src/main/java/nl/svenar/common/structure/PRPermission.java
@@ -78,4 +78,16 @@ public class PRPermission {
     public void setValue(boolean value) {
         this.value = value;
     }
+
+    @Override
+    public String toString() {
+        return "permission:" + name + ", value:" + value;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + toString().hashCode();
+        return result;
+    }
 }

--- a/src/main/java/nl/svenar/common/structure/PRPlayer.java
+++ b/src/main/java/nl/svenar/common/structure/PRPlayer.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 /**
  * Structure to store player data.
@@ -38,14 +39,14 @@ public class PRPlayer {
 
     private UUID uuid;
     private String name;
-    private ArrayList<String> ranks;
+    private ArrayList<PRPlayerRank> ranks;
     private ArrayList<PRPermission> permissions;
     private ArrayList<String> usertags;
     private long playtime;
 
     public PRPlayer() {
         this.name = "";
-        this.ranks = new ArrayList<String>();
+        this.ranks = new ArrayList<PRPlayerRank>();
         this.permissions = new ArrayList<PRPermission>();
         this.usertags = new ArrayList<String>();
         this.playtime = 0L;
@@ -92,7 +93,7 @@ public class PRPlayer {
      * 
      * @return String rank of the player
      */
-    public List<String> getRanks() {
+    public List<PRPlayerRank> getRanks() {
         return this.ranks;
     }
 
@@ -101,7 +102,7 @@ public class PRPlayer {
      * 
      * @param ranks
      */
-    public void setRanks(ArrayList<String> ranks) {
+    public void setRanks(ArrayList<PRPlayerRank> ranks) {
         this.ranks = ranks;
     }
 
@@ -110,7 +111,7 @@ public class PRPlayer {
      * 
      * @param rank
      */
-    public void setRank(String rank) {
+    public void setRank(PRPlayerRank rank) {
         this.ranks.clear();
         this.ranks.add(rank);
     }
@@ -120,7 +121,7 @@ public class PRPlayer {
      * 
      * @param rank
      */
-    public void addRank(String rank) {
+    public void addRank(PRPlayerRank rank) {
         if (!this.ranks.contains(rank)) {
             this.ranks.add(rank);
         }
@@ -131,7 +132,7 @@ public class PRPlayer {
      * 
      * @param rank
      */
-    public void removeRank(String rank) {
+    public void removeRank(PRPlayerRank rank) {
         if (this.ranks.contains(rank)) {
             this.ranks.remove(rank);
         }
@@ -304,8 +305,13 @@ public class PRPlayer {
         + ", usertags:[<<USERTAGS>>]";
 
         String ranks = "";
-        for (String rank : getRanks()) {
-            ranks += rank + ";";
+        for (PRPlayerRank rank : getRanks()) {
+            ranks += rank.getName() + " (";
+            for (Entry<String, String> entry : rank.getTags().entrySet()) {
+                ranks += entry.getKey() + "=" + entry.getValue() + ",";
+            }
+            ranks = rank.getTags().size() > 0 ? ranks.substring(0, ranks.length() - 1) : "";
+            ranks += ");";
         }
         ranks = ranks.length() > 0 ? ranks.substring(0, ranks.length() - 1) : "";
 

--- a/src/main/java/nl/svenar/common/structure/PRPlayer.java
+++ b/src/main/java/nl/svenar/common/structure/PRPlayer.java
@@ -294,4 +294,44 @@ public class PRPlayer {
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        String output = "uuid:" + uuid.toString()
+        + ", name:" + name
+        + ", ranks:[<<RANKS>>]"
+        + ", permissions:[<<PERMISSIONS>>]"
+        + ", usertags:[<<USERTAGS>>]";
+
+        String ranks = "";
+        for (String rank : getRanks()) {
+            ranks += rank + ";";
+        }
+        ranks = ranks.length() > 0 ? ranks.substring(0, ranks.length() - 1) : "";
+
+        String permissions = "";
+        for (PRPermission permission : getPermissions()) {
+            permissions += permission.toString() + ";";
+        }
+        permissions = permissions.length() > 0 ? permissions.substring(0, permissions.length() - 1) : "";
+
+        String usertags = "";
+        for (String usertag : getUsertags()) {
+            usertags += usertag + ";";
+        }
+        usertags = usertags.length() > 0 ? usertags.substring(0, usertags.length() - 1) : "";
+
+        output = output.replaceAll("<<RANKS>>", ranks);
+        output = output.replaceAll("<<PERMISSIONS>>", permissions);
+        output = output.replaceAll("<<USERTAGS>>", usertags);
+
+        return output;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + toString().hashCode();
+        return result;
+    }
 }

--- a/src/main/java/nl/svenar/common/structure/PRPlayerRank.java
+++ b/src/main/java/nl/svenar/common/structure/PRPlayerRank.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public class PRPlayerRank {
     
-    private String rank;
+    private String name;
     private HashMap<String, String> tags;
 
     public PRPlayerRank() {
@@ -13,11 +13,11 @@ public class PRPlayerRank {
 
     public PRPlayerRank(String name) {
         this();
-        this.rank = name;
+        this.name = name;
     }
 
     public String getName() {
-        return this.rank;
+        return this.name;
     }
 
     public HashMap<String, String> getTags() {

--- a/src/main/java/nl/svenar/common/structure/PRPlayerRank.java
+++ b/src/main/java/nl/svenar/common/structure/PRPlayerRank.java
@@ -1,0 +1,26 @@
+package nl.svenar.common.structure;
+
+import java.util.HashMap;
+
+public class PRPlayerRank {
+    
+    private String rank;
+    private HashMap<String, String> tags;
+
+    public PRPlayerRank() {
+        this.tags = new HashMap<>();
+    }
+
+    public PRPlayerRank(String name) {
+        this();
+        this.rank = name;
+    }
+
+    public String getName() {
+        return this.rank;
+    }
+
+    public HashMap<String, String> getTags() {
+        return this.tags;
+    }
+}

--- a/src/main/java/nl/svenar/common/structure/PRRank.java
+++ b/src/main/java/nl/svenar/common/structure/PRRank.java
@@ -400,4 +400,54 @@ public class PRRank {
     public void setWeight(int weight) {
         this.weight = weight;
     }
+
+    @Override
+    public String toString() {
+        String output = "name:" + name
+        + ", isDefault:" + isDefault
+        + ", permissions:[<<PERMISSIONS>>]"
+        + ", inheritances:[<<INHERITANCES>>]"
+        + ", chatPrefix:" + chatPrefix
+        + ", chatSuffix:" + chatSuffix
+        + ", chatNamecolor:" + chatNamecolor
+        + ", chatChatcolor:" + chatChatcolor
+        + ", economyBuyable:" + economyBuyable
+        + ", economyCost:" + economyCost
+        + ", economyDescription:" + economyDescription
+        + ", economyBuyCommand:" + economyBuyCommand
+        + ", buyableRanks:[<<BUYABLERANKS>>]"
+        + ", weight:" + weight
+        + ", economyBuyable:" + economyBuyable;
+
+        String permissions = "";
+        for (PRPermission permission : getPermissions()) {
+            permissions += permission.toString() + ";";
+        }
+        permissions = permissions.length() > 0 ? permissions.substring(0, permissions.length() - 1) : "";
+
+        String inheritances = "";
+        for (String inheritance : getInheritances()) {
+            inheritances += inheritance + ";";
+        }
+        inheritances = inheritances.length() > 0 ? inheritances.substring(0, inheritances.length() - 1) : "";
+
+        String buyableRanks = "";
+        for (String buyable : getBuyableRanks()) {
+            buyableRanks += buyable + ";";
+        }
+        buyableRanks = buyableRanks.length() > 0 ? buyableRanks.substring(0, buyableRanks.length() - 1) : "";
+
+        output = output.replaceAll("<<PERMISSIONS>>", permissions);
+        output = output.replaceAll("<<INHERITANCES>>", inheritances);
+        output = output.replaceAll("<<BUYABLERANKS>>", buyableRanks);
+
+        return output;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + toString().hashCode();
+        return result;
+    }
 }

--- a/src/main/java/nl/svenar/common/utils/AsyncReadFile.java
+++ b/src/main/java/nl/svenar/common/utils/AsyncReadFile.java
@@ -1,0 +1,105 @@
+package nl.svenar.common.utils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class AsyncReadFile {
+
+    private Path path;
+    private DataBuffer dataBuffer;
+
+    public void setFile(String filePath) {
+        this.path = Paths.get(filePath);
+    }
+
+    public void read() {
+        this.dataBuffer = new DataBuffer();
+
+        AsynchronousFileChannel channel = null;
+        try {
+            channel = AsynchronousFileChannel.open(this.path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+
+        // start off the asynch read.
+        channel.read(buffer, 0, channel, new CallbackHandler(buffer, dataBuffer));
+    }
+
+    public String getData() {
+        return this.dataBuffer.getData();
+    }
+
+    public boolean isReady() {
+        return this.dataBuffer.isReady();
+    }
+
+    public long getFileLength() {
+        try {
+            return Files.size(this.path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return -1;
+    }
+
+    private class DataBuffer {
+        private String data;
+        private boolean doneReading;
+
+        public void addData(String data) {
+            this.data += data;
+        }
+
+        public String getData() {
+            return this.data;
+        }
+
+        public void setReady(boolean ready) {
+            this.doneReading = ready;
+        }
+
+        public boolean isReady() {
+            return this.doneReading;
+        }
+    }
+
+    private class CallbackHandler implements CompletionHandler<Integer, AsynchronousFileChannel> {
+
+        private int position = 0;
+        private ByteBuffer buffer = null;
+        private DataBuffer dataBuffer;
+
+        public CallbackHandler(ByteBuffer buffer, DataBuffer dataBuffer) {
+            this.buffer = buffer;
+            this.dataBuffer = dataBuffer;
+        }
+
+        @Override
+        public void completed(Integer result, AsynchronousFileChannel attachment) {
+            if (result != -1) {
+                position += result;
+                this.dataBuffer.addData(new String(buffer.array(), 0, result));
+
+                buffer.clear();
+
+                attachment.read(buffer, position, attachment, this);
+            } else {
+                this.dataBuffer.setReady(true);
+            }
+        }
+
+        @Override
+        public void failed(Throwable exc, AsynchronousFileChannel attachment) {
+            exc.printStackTrace();
+        }
+
+    }
+}

--- a/src/main/java/nl/svenar/common/utils/PRUtil.java
+++ b/src/main/java/nl/svenar/common/utils/PRUtil.java
@@ -24,4 +24,13 @@ public class PRUtil {
         Collections.reverse(ranks);
         return ranks;
     }
+
+    public static boolean containsIgnoreCase(List<String> objects, String object) {
+        for (String obj : objects) {
+            if (obj.equalsIgnoreCase(object)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,9 @@ general:
   playtime-update-interval: 60
   case-sensitive-permissions: false
   disable-op: false
+bungeecord:
+  enabled: false
+  server-name: Global
 storage:
   type: YAML
   mysql:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,10 +20,6 @@ chat:
 tablist_modification:
   enabled: true
   format: '&a[world]&r [usertag] [prefix] [subprefix] [player] [subsuffix] [suffix]'
-  sorting:
-    enabled: true
-    reverse: false
-    update-interval: 5
 nametagedit:
   prefix: '[usertag] [prefix] [subprefix]'
   suffix: '[subsuffix] [suffix]'

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -67,9 +67,14 @@ lang:
             success-set: "&aChanged buy description to '[description]' on rank: [rank]"
             failed-set: "&cFailed to set buy description to '[description]' on rank: [rank]"
          config:
-            arguments: "<removeworldtag / (enable/disable chat_formatting/tablist_formatting/tablist_sorting/reverse_tablist_sorting/op/casesensitive_permissions) / set (playtime_update_interval <seconds> / autosave_files_interval <seconds> / language <string>)>"
+            arguments: "<removeworldtag / (enable/disable chat_formatting/tablist_formatting/op/casesensitive_permissions) / set (playtime_update_interval <seconds> / autosave_files_interval <seconds> / language <string>)>"
             description: "Edit fields in the configuration file"
             removed-world-tag: "&aThe world tag has been removed!"
+            state-changed: "&eChanged [config_target] from &c[old_state] &eto &a[new_state]"
+            numbers-only: "&cOnly numbers are allowed!"
+         tablist:
+            arguments: "<removeworldtag / (enable/disable tablist_sorting/reverse_tablist_sorting) / set (sorting_update_interval <seconds> / header_footer_update_interval <ticks>)>"
+            description: "Edit fields in the tablist configuration file"
             state-changed: "&eChanged [config_target] from &c[old_state] &eto &a[new_state]"
             numbers-only: "&cOnly numbers are allowed!"
          factoryreset:

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -304,6 +304,17 @@ lang:
             failed-downloaded: "&cFailed to download data from the web editor!"
             incompatible-version: "&cIncompattible PowerRanks version! (editor: [downloaded_version] | server: [version])"
             download-stats: "&aLoaded [rank_count] ranks and [player_count] players from the web editor!"
+         we:
+            arguments: "<start/load [id]>"
+            description: "Upload/download your server data to/from the PowerRanks web-editor"
+            preparing-session: "&aPreparing web editor..."
+            timed-out: "&cThe web editor has timed out! Please try again later."
+            downloading-data: "&aDownloading data from the web editor..."
+            success-downloaded: "&aFinished downloading data from the web editor! &cIt is recommended to restart your server."
+            downloaded-invalid-data: "&cInvalid web editor data!"
+            failed-downloaded: "&cFailed to download data from the web editor!"
+            incompatible-version: "&cIncompattible PowerRanks version! (editor: [downloaded_version] | server: [version])"
+            download-stats: "&aLoaded [rank_count] ranks and [player_count] players from the web editor!"
          dump:
             arguments: ""
             description: "Upload your server data to the PowerRanks server for debugging"

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -73,10 +73,17 @@ lang:
             state-changed: "&eChanged [config_target] from &c[old_state] &eto &a[new_state]"
             numbers-only: "&cOnly numbers are allowed!"
          tablist:
-            arguments: "<removeworldtag / (enable/disable tablist_sorting/reverse_tablist_sorting) / set (sorting_update_interval <seconds> / header_footer_update_interval <ticks>)>"
+            arguments: "<removeworldtag / (enable/disable tablist_sorting/reverse_tablist_sorting) / set (sorting_update_interval <seconds> / header_footer_update_interval <ticks>) / animation ...>"
             description: "Edit fields in the tablist configuration file"
             state-changed: "&eChanged [config_target] from &c[old_state] &eto &a[new_state]"
             numbers-only: "&cOnly numbers are allowed!"
+            animation:
+               arguments: "<list>"
+               unknown-animation: "&cUnknown animation name"
+               already-exists: "&cAn animation with that name already exists"
+               does-not-exists: "&cAn animation with that name does not exists"
+               created: "&aAnimation created"
+               deleted: "&aAnimation deleted"
          factoryreset:
             arguments: "[reset-ID]"
             description: "Reset the configuration and remove all rank/player data"

--- a/src/main/resources/tablist.yml
+++ b/src/main/resources/tablist.yml
@@ -12,7 +12,7 @@ header-footer:
   footer:
   - "#01b0fb-#11a5fa-#229af8-#328ff7-#4284f5-#5279f4-#636ef2-#7363f1-#8358ef-#934dee-#a442ec-#b437eb-#c42ce9-#d421e8-#e516e6-#f50be5-#f50be5-#e516e6-#d421e8-#c42ce9-#b437eb-#a442ec-#934dee-#8358ef-#7363f1-#636ef2-#5279f4-#4284f5-#328ff7-#229af8-#11a5fa-#01b0fb-"
   - ""
-  - "&b&lFooter"
+  - "#5ffb15d#61fb15e#64fb16f#66fb16a#68fb17u#6afb17l#6dfb17t #6ffb18h#71fb18e#74fb18a#76fc19d#78fc19e#7afc1ar #7dfc1a #7ffc1af#81fc1bo#84fc1bo#86fc1ct#88fc1ce#8afc1cr#8dfc1d, #8ffc1dc#91fc1dh#93fc1ea#96fc1en#98fc1fg#9afc1fe #9dfc1fi#9ffc20n #a1fc20t#a3fd21a#a6fd21b#a8fd21l#aafd22i#adfd22s#affd22t#b1fd23.#b3fd23y#b6fd24m#b8fd24l"
   animations:
     demo:
       delay: 5
@@ -29,4 +29,5 @@ header-footer:
       - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#FFFFFFR#fb541fa#fb3824n#fc1c29k#fd002es"
       - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#FFFFFFa#fb3824n#fc1c29k#fd002es"
       - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#FFFFFFn#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#FFFFFFk#fd002es"
       - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#FFFFFFs"

--- a/src/main/resources/tablist.yml
+++ b/src/main/resources/tablist.yml
@@ -1,0 +1,32 @@
+sorting:
+  enabled: true
+  reverse: false
+  update-interval: 5
+header-footer:
+  enabled: true
+  update-interval: 1
+  header:
+  - "{animation:demo}"
+  - ""
+  - "#01b0fb-#11a5fa-#229af8-#328ff7-#4284f5-#5279f4-#636ef2-#7363f1-#8358ef-#934dee-#a442ec-#b437eb-#c42ce9-#d421e8-#e516e6-#f50be5-#f50be5-#e516e6-#d421e8-#c42ce9-#b437eb-#a442ec-#934dee-#8358ef-#7363f1-#636ef2-#5279f4-#4284f5-#328ff7-#229af8-#11a5fa-#01b0fb-"
+  footer:
+  - "#01b0fb-#11a5fa-#229af8-#328ff7-#4284f5-#5279f4-#636ef2-#7363f1-#8358ef-#934dee-#a442ec-#b437eb-#c42ce9-#d421e8-#e516e6-#f50be5-#f50be5-#e516e6-#d421e8-#c42ce9-#b437eb-#a442ec-#934dee-#8358ef-#7363f1-#636ef2-#5279f4-#4284f5-#328ff7-#229af8-#11a5fa-#01b0fb-"
+  - ""
+  - "&b&lFooter"
+  animations:
+    demo:
+      delay: 5
+      frames:
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#FFFFFFP#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#FFFFFFo#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#FFFFFFw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#FFFFFFe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#FFFFFFr#fa701aR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#FFFFFFR#fb541fa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#FFFFFFa#fb3824n#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#FFFFFFn#fc1c29k#fd002es"
+      - "#f6fb00P#f7df05o#f8c30aw#f8a70fe#f98b14r#fa701aR#fb541fa#fb3824n#fc1c29k#FFFFFFs"

--- a/src/main/resources/tablist.yml
+++ b/src/main/resources/tablist.yml
@@ -12,7 +12,7 @@ header-footer:
   footer:
   - "#01b0fb-#11a5fa-#229af8-#328ff7-#4284f5-#5279f4-#636ef2-#7363f1-#8358ef-#934dee-#a442ec-#b437eb-#c42ce9-#d421e8-#e516e6-#f50be5-#f50be5-#e516e6-#d421e8-#c42ce9-#b437eb-#a442ec-#934dee-#8358ef-#7363f1-#636ef2-#5279f4-#4284f5-#328ff7-#229af8-#11a5fa-#01b0fb-"
   - ""
-  - "#5ffb15d#61fb15e#64fb16f#66fb16a#68fb17u#6afb17l#6dfb17t #6ffb18h#71fb18e#74fb18a#76fc19d#78fc19e#7afc1ar #7dfc1a #7ffc1af#81fc1bo#84fc1bo#86fc1ct#88fc1ce#8afc1cr#8dfc1d, #8ffc1dc#91fc1dh#93fc1ea#96fc1en#98fc1fg#9afc1fe #9dfc1fi#9ffc20n #a1fc20t#a3fd21a#a6fd21b#a8fd21l#aafd22i#adfd22s#affd22t#b1fd23.#b3fd23y#b6fd24m#b8fd24l"
+  - "#5ffb15d#61fb15e#64fb16f#66fb16a#68fb17u#6afb17l#6dfb17t #6ffb18h#71fb18e#74fb18a#76fc19d#78fc19e#7afc1ar #7ffc1af#81fc1bo#84fc1bo#86fc1ct#88fc1ce#8afc1cr#8dfc1d, #8ffc1dc#91fc1dh#93fc1ea#96fc1en#98fc1fg#9afc1fe #9dfc1fi#9ffc20n #a1fc20t#a3fd21a#a6fd21b#a8fd21l#aafd22i#adfd22s#affd22t#b1fd23.#b3fd23y#b6fd24m#b8fd24l"
   animations:
     demo:
       delay: 5


### PR DESCRIPTION
### Changelog:
* Added experimental rank & player data synchronization for multi-server support using MySQL
* Added '/pr config enable/disable bungeecord'
* Added '/pr config set bungeecord_server_name <servername>'
* Added more information to '/pr dump' when it fails
* Added tablist header & footer manager
* Added tablist header & footer animations
* Added '/pr tablist ...'
* Moved tablist configuration to tablist.yml
* Removed '/pr config enable/disable tablist_sorting'
* Removed '/pr config enable/disable reverse_tablist_sorting'
* Fixed '/pr reload <config/all>' to include more configuration files
* Fixed tablist update spamming verbose log
* Fixed language message for '/pr we' 
