### PR TITLE
feat. added batched process in PermissionRegistry to avoid lagging 

### DIFF
--- a/Bukkit/pom.xml
+++ b/Bukkit/pom.xml
@@ -148,7 +148,7 @@
 		</repository>
 		<repository>
 			<id>placeholderapi</id>
-			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+			<url>https://repo.extendedclip.com/releases/</url>
 		</repository>
 		<repository>
 			<id>jitpack.io</id>
@@ -192,7 +192,7 @@
 		<dependency>
 			<groupId>me.clip</groupId>
 			<artifactId>placeholderapi</artifactId>
-			<version>2.11.4</version>
+			<version>2.11.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/Bukkit/src/main/java/nl/svenar/powerranks/bukkit/PowerRanks.java
+++ b/Bukkit/src/main/java/nl/svenar/powerranks/bukkit/PowerRanks.java
@@ -453,7 +453,7 @@ public class PowerRanks extends JavaPlugin implements Listener {
 		new BukkitRunnable() {
 			@Override
 			public void run() {
-				permissionRegistry.tick();
+				permissionRegistry.tick(256);
 			}
 		}.runTaskTimer(this, 1, 1);
 	}

--- a/Core/src/main/java/nl/svenar/powerranks/common/storage/PermissionRegistry.java
+++ b/Core/src/main/java/nl/svenar/powerranks/common/storage/PermissionRegistry.java
@@ -17,9 +17,10 @@ public class PermissionRegistry {
         this.queue.add(permissionNode);
     }
 
-    public void tick() {
-        String permissionNode = this.queue.poll();
-        if (permissionNode != null) {
+    public void tick(int batchSize) {
+        for (int i = 0; i < batchSize; i++) {
+            String permissionNode = this.queue.poll();
+            if (permissionNode == null) break;
             addPermission(permissionNode);
         }
     }

--- a/Core/src/main/java/nl/svenar/powerranks/common/structure/PRPlayerRank.java
+++ b/Core/src/main/java/nl/svenar/powerranks/common/structure/PRPlayerRank.java
@@ -72,7 +72,7 @@ public class PRPlayerRank {
         if (tagName.equalsIgnoreCase("expires")) {
             long currentTimeMillis = System.currentTimeMillis();
             tagValue = PRUtil.timeStringToSecondsConverter(String.valueOf(tagValue));
-            tagValue = currentTimeMillis + ((int) tagValue * 1000);
+            tagValue = currentTimeMillis + ((int) tagValue * 1000L);
         }
 
         if (tagName.equalsIgnoreCase("world")) {


### PR DESCRIPTION
Recently, I found that garbage collection is often stuck after adding this plugin to my server. After I performed heap dump, I found that a ConcurrentLinkedQueue with many nodes occupied most of the resources and could not be released.
After troubleshooting, I found the PermissionRegistry of PowerRanks. This queue is polled only once per tick during running. In some cases where permission requests are frequent (for example, in my game server), the queue will block, and then the game will get stuck.
This PR aims to eliminate this kind of stuck problem. By modifying the code and adding batch processing logic, the current code will poll 256 nodes at a time. After testing, the problem of stuck problem has been completely solved.

In addition, as for the problem of accidentally modifying pom.xml, the main reason is that if I don't modify it to this address, I can't build it. If it's unnecessary, you can roll back the modification.